### PR TITLE
feat: handle scenario where getTip is null

### DIFF
--- a/apps/course-builder-web/src/app/tips/[slug]/page.tsx
+++ b/apps/course-builder-web/src/app/tips/[slug]/page.tsx
@@ -12,11 +12,16 @@ import {getServerAuthSession} from '@/server/auth'
 import {getAbility} from '@/lib/ability'
 import {getTip} from '@/lib/tips'
 import ReactMarkdown from 'react-markdown'
+import {notFound} from 'next/navigation'
 
 export default async function TipPage({params}: {params: {slug: string}}) {
   const session = await getServerAuthSession()
   const ability = getAbility({user: session?.user})
   const tip = await getTip(params.slug)
+
+  if (!tip) {
+    notFound()
+  }
 
   return (
     <div>

--- a/apps/course-builder-web/src/app/tips/_components/edit-tip-form.tsx
+++ b/apps/course-builder-web/src/app/tips/_components/edit-tip-form.tsx
@@ -49,8 +49,15 @@ export function EditTipForm({tip}: {tip: Tip}) {
     api.tips.update.useMutation()
 
   const onSubmit = async (values: z.infer<typeof NewTipFormSchema>) => {
-    const {slug} = await updateTip({tipId: tip._id, ...values})
-    router.push(`/tips/${slug}`)
+    const updatedTip = await updateTip({tipId: tip._id, ...values})
+
+    if (!updatedTip) {
+      // handle edge case, e.g. toast an error message
+    } else {
+      const {slug} = updatedTip
+
+      router.push(`/tips/${slug}`)
+    }
   }
 
   const [activeToolbarTab, setActiveToolbarTab] = React.useState(

--- a/apps/course-builder-web/src/app/tips/_components/new-tip-form.tsx
+++ b/apps/course-builder-web/src/app/tips/_components/new-tip-form.tsx
@@ -48,7 +48,12 @@ export function NewTipForm() {
 
   const onSubmit = async (values: z.infer<typeof NewTipFormSchema>) => {
     const tip = await createTip(values)
-    router.push(`/tips/${tip.slug}`)
+
+    if (!tip) {
+      // handle edge, e.g. toast an error message
+    } else {
+      router.push(`/tips/${tip.slug}`)
+    }
   }
 
   return (

--- a/apps/course-builder-web/src/inngest/functions/tips/chat.ts
+++ b/apps/course-builder-web/src/inngest/functions/tips/chat.ts
@@ -8,6 +8,7 @@ import {sanityQuery} from '@/server/sanity.server'
 import type {ChatCompletionRequestMessage} from 'openai-edge'
 import {promptActionExecutor} from '@/lib/prompt.action-executor'
 import {Liquid} from 'liquidjs'
+import {NonRetriableError} from 'inngest'
 
 export const tipChat = inngest.createFunction(
   {
@@ -21,6 +22,10 @@ export const tipChat = inngest.createFunction(
     const tip = await step.run(`load tip`, async () => {
       return await getTip(event.data.tipId)
     })
+
+    if (!tip) {
+      throw new NonRetriableError(`Tip not found for id (${event.data.tipId})`)
+    }
 
     const workflow = await step.run('Load Workflow', async () => {
       return await sanityQuery(

--- a/apps/course-builder-web/src/lib/tips.ts
+++ b/apps/course-builder-web/src/lib/tips.ts
@@ -17,7 +17,7 @@ const TipSchema = z.object({
 export type Tip = z.infer<typeof TipSchema>
 
 export async function getTip(slugOrId: string) {
-  return await sanityQuery<Tip>(`*[_type == "tip" && (_id == "${slugOrId}" || slug.current == "${slugOrId}")][0]{
+  return await sanityQuery<Tip | null>(`*[_type == "tip" && (_id == "${slugOrId}" || slug.current == "${slugOrId}")][0]{
           _id,
           _type,
           "_updatedAt": ^._updatedAt,

--- a/apps/course-builder-web/src/trpc/api/routers/tips.ts
+++ b/apps/course-builder-web/src/trpc/api/routers/tips.ts
@@ -165,6 +165,10 @@ export const tipsRouter = createTRPCRouter({
 
       const currentTip = await getTip(input.tipId)
 
+      if (!currentTip) {
+        throw new Error('Not found')
+      }
+
       if (input.title !== currentTip.title) {
         await sanityMutation([
           {


### PR DESCRIPTION
It's possible that the `getTip` function is directed to look up a Tip
that doesn't exist in Sanity. So the type needs to reflect that by
having a return type of `Tip | null`. The type errors then helpfully
pointed to some places where we needed to handle the `null` case.

![null](https://media1.giphy.com/media/KDnxbHF3N7EDKhZIGE/giphy.gif?cid=d1fd59ab1x4nx7ai8k7e8kcrj17s3fkh97t4xy75n1psuex6&ep=v1_gifs_search&rid=giphy.gif&ct=g)
