### PR TITLE
style: resizable panes and dark mode

### DIFF
--- a/apps/course-builder-web/package.json
+++ b/apps/course-builder-web/package.json
@@ -117,6 +117,7 @@
     "next-auth": "^4.24.5",
     "next-axiom": "^1.1.1",
     "next-mdx-remote": "^4.4.1",
+    "next-themes": "^0.2.1",
     "npm": "^10.2.1",
     "openai": "^4.26.0",
     "openai-edge": "^1.2.2",

--- a/apps/course-builder-web/package.json
+++ b/apps/course-builder-web/package.json
@@ -129,6 +129,7 @@
     "react-hook-form": "^7.48.0",
     "react-icons": "^4.11.0",
     "react-markdown": "^9.0.0",
+    "react-resizable-panels": "^2.0.9",
     "resend": "^3.2.0",
     "sanity": "^3.18.1",
     "sanity-plugin-asset-source-unsplash": "^1.1.2",

--- a/apps/course-builder-web/src/app/_components/codemirror.tsx
+++ b/apps/course-builder-web/src/app/_components/codemirror.tsx
@@ -39,7 +39,7 @@ export const CodemirrorEditor = ({
   })
 
   return (
-    <div className="h-full flex-shrink-0 border-t">
+    <div className="h-full flex-shrink-0">
       <div ref={codemirrorElementRef}></div>
     </div>
   )
@@ -54,6 +54,7 @@ const CourseBuilderEditorTheme = {
     padding: '2rem 0',
     fontSize: '14px',
     fontFamily: 'var(--font-mono)',
+    color: 'hsl(var(--foreground))',
   },
   '.cm-line': {
     padding: '0 2rem',
@@ -74,6 +75,9 @@ const CourseBuilderEditorTheme = {
   },
   '.cm-activeLine': {
     backgroundColor: 'hsl(var(--foreground) / 3%)',
+  },
+  '.cm-cursor': {
+    borderLeft: '1px solid hsl(var(--foreground))',
   },
 }
 

--- a/apps/course-builder-web/src/app/_components/resource-assistant.tsx
+++ b/apps/course-builder-web/src/app/_components/resource-assistant.tsx
@@ -6,7 +6,7 @@ import { useSocket } from '@/hooks/use-socket'
 import { EnterIcon } from '@sanity/icons'
 import type { ChatCompletionRequestMessage } from 'openai-edge'
 
-import { Button, Textarea } from '@coursebuilder/ui'
+import { Button, ResizableHandle, ResizablePanel, ResizablePanelGroup, Textarea } from '@coursebuilder/ui'
 
 export function ResourceAssistant({
   resourceId,
@@ -44,8 +44,8 @@ export function ResourceAssistant({
 
   return (
     <div className="flex h-full w-full flex-col justify-start">
-      <div>
-        <h3 className="inline-flex p-5 pb-3 text-lg font-bold">Assistant</h3>
+      <div className="flex items-center justify-between gap-10 border-b p-5">
+        <h3 className="inline-flex text-lg font-bold">Assistant</h3>
         {availableWorkflows.length > 1 && (
           <AssistantWorkflowSelector
             initialValue={selectedWorkflow}
@@ -56,14 +56,16 @@ export function ResourceAssistant({
           />
         )}
       </div>
-      <ResourceChatResponse requestId={resourceId} />
-      <div className="flex w-full flex-col items-start border-t">
-        <div className="relative w-full">
+      <ResizablePanelGroup direction="vertical">
+        <ResizablePanel defaultSize={85}>
+          <ResourceChatResponse requestId={resourceId} />
+        </ResizablePanel>
+        <ResizableHandle />
+        <ResizablePanel defaultSize={15} minSize={5} className="relative flex w-full flex-col items-start">
           <Textarea
             ref={textareaRef}
-            className="w-full rounded-none border-0 border-b px-5 py-4 pr-10"
+            className="w-full flex-grow rounded-none border-0 px-5 py-4 pr-10 focus-visible:ring-0"
             placeholder="Direct Assistant..."
-            rows={4}
             onKeyDown={async (event) => {
               if (event.key === 'Enter' && !event.shiftKey) {
                 event.preventDefault()
@@ -74,7 +76,7 @@ export function ResourceAssistant({
           />
           <Button
             type="button"
-            className="absolute right-2 top-2 flex h-6 w-6 items-center justify-center p-0"
+            className="absolute right-2 top-4 flex h-6 w-6 items-center justify-center p-0"
             variant="outline"
             onClick={async (event) => {
               event.preventDefault()
@@ -86,8 +88,8 @@ export function ResourceAssistant({
           >
             <EnterIcon className="w-4" />
           </Button>
-        </div>
-      </div>
+        </ResizablePanel>
+      </ResizablePanelGroup>
     </div>
   )
 }

--- a/apps/course-builder-web/src/app/_components/resource-chat-response.tsx
+++ b/apps/course-builder-web/src/app/_components/resource-chat-response.tsx
@@ -69,17 +69,17 @@ export function ResourceChatResponse({ requestId }: { requestId: string }) {
   })
 
   return (
-    <ScrollArea viewportRef={div} className="h-[50vh] w-full scroll-smooth text-sm">
+    <ScrollArea viewportRef={div} className="h-full w-full scroll-smooth text-sm">
       {messages.length === 0 && session.status === 'authenticated' ? (
-        <div className="prose prose-sm px-5">
+        <div className="prose prose-sm dark:prose-invert p-5">
           {`Hi ${session.data.user.name?.split(' ')[0]}, I’m your assistant and I’m here to help you get things done
           faster.`}
         </div>
       ) : null}
       {messages.map((message, index) => (
-        <div key={index} className="border-b p-5">
+        <div key={index} className="border-b p-5 last-of-type:border-b-0">
           <MessageHeader userId={message.userId} />
-          <ReactMarkdown className="prose prose-sm">{message.body}</ReactMarkdown>
+          <ReactMarkdown className="prose prose-sm dark:prose-invert">{message.body}</ReactMarkdown>
         </div>
       ))}
     </ScrollArea>

--- a/apps/course-builder-web/src/app/articles/[slug]/edit/page.tsx
+++ b/apps/course-builder-web/src/app/articles/[slug]/edit/page.tsx
@@ -18,9 +18,5 @@ export default async function ArticleEditPage({ params }: { params: { slug: stri
     notFound()
   }
 
-  return (
-    <div className="relative mx-auto flex h-full w-full flex-grow flex-col items-center justify-center">
-      <EditArticleForm key={article.slug} article={article} />
-    </div>
-  )
+  return <EditArticleForm key={article.slug} article={article} />
 }

--- a/apps/course-builder-web/src/app/articles/_components/cloudinary-media-browser.tsx
+++ b/apps/course-builder-web/src/app/articles/_components/cloudinary-media-browser.tsx
@@ -23,7 +23,7 @@ export const CloudinaryMediaBrowser = () => {
   return (
     <div>
       <h3 className="inline-flex px-5 text-lg font-bold">Media Browser</h3>
-      <div className="grid grid-cols-3 gap-1 p-2">
+      <div className="grid grid-cols-3 gap-1 px-5">
         {images.map((asset) => {
           return asset?.url ? (
             <div

--- a/apps/course-builder-web/src/app/articles/_components/edit-article-form.tsx
+++ b/apps/course-builder-web/src/app/articles/_components/edit-article-form.tsx
@@ -25,6 +25,10 @@ import {
   FormLabel,
   FormMessage,
   Input,
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+  ScrollArea,
   Select,
   SelectContent,
   SelectItem,
@@ -91,215 +95,227 @@ export function EditArticleForm({ article }: { article: Article }) {
   const currentSocialImage = form.watch('socialImage')
 
   return (
-    <Form {...form}>
-      <form
-        className="relative flex h-full flex-grow flex-col"
-        onSubmit={form.handleSubmit(onSubmit, (error) => {
-          console.log({ error })
-        })}
-      >
-        <div className="md:bg-muted bg-muted/60 sticky top-0 z-10 flex h-9 w-full items-center justify-between px-1 backdrop-blur-md md:backdrop-blur-none">
-          <div className="flex items-center gap-2">
-            <Button className="px-0" asChild variant="link">
-              <Link href={`/${article.slug}`} className="aspect-square">
-                ←
-              </Link>
-            </Button>
-            <span className="font-medium">
-              Article <span className="hidden font-mono text-xs font-normal md:inline-block">({article._id})</span>
-            </span>
-          </div>
-          <Button
-            type="submit"
-            variant="default"
-            size="sm"
-            className="h-7"
-            disabled={updateArticleStatus === 'loading'}
-          >
-            Save
+    <>
+      <div className="md:bg-muted bg-muted/60 sticky top-0 z-10 flex h-9 w-full items-center justify-between px-1 backdrop-blur-md md:backdrop-blur-none">
+        <div className="flex items-center gap-2">
+          <Button className="px-0" asChild variant="link">
+            <Link href={`/${article.slug}`} className="aspect-square">
+              ←
+            </Link>
           </Button>
+          <span className="font-medium">
+            Article <span className="hidden font-mono text-xs font-normal md:inline-block">({article._id})</span>
+          </span>
         </div>
-        <div className="flex h-full flex-grow flex-col border-t md:flex-row">
-          <div className="grid-cols-12 md:grid">
-            <div className="col-span-3 flex flex-col gap-5 py-5 md:h-full md:border-r">
-              <FormField
-                control={form.control}
-                name="title"
-                render={({ field }) => (
-                  <FormItem className="px-5">
-                    <FormLabel>Title</FormLabel>
-                    <FormDescription>
-                      A title should summarize the tip and explain what it is about clearly.
-                    </FormDescription>
-                    <Input {...field} />
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={form.control}
-                name="slug"
-                render={({ field }) => (
-                  <FormItem className="px-5">
-                    <FormLabel>Slug</FormLabel>
-                    <Input {...field} />
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={form.control}
-                name="visibility"
-                render={({ field }) => (
-                  <FormItem className="px-5">
-                    <FormLabel>Visibility</FormLabel>
-                    <Select onValueChange={field.onChange} defaultValue={field.value}>
-                      <FormControl>
-                        <SelectTrigger>
-                          <SelectValue placeholder="Choose state" />
-                        </SelectTrigger>
-                      </FormControl>
-                      <SelectContent className="">
-                        {ArticleVisibilitySchema.options.map((option) => {
-                          const value = option._def.value
-                          return (
-                            <SelectItem key={value} value={value}>
-                              {value}
-                            </SelectItem>
-                          )
-                        })}
-                      </SelectContent>
-                    </Select>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={form.control}
-                name="state"
-                render={({ field }) => (
-                  <FormItem className="px-5">
-                    <FormLabel>State</FormLabel>
-                    <Input {...field} readOnly disabled />
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={form.control}
-                name="description"
-                render={({ field }) => (
-                  <FormItem className="px-5">
-                    <FormLabel>Short Description</FormLabel>
-                    <FormDescription>Used as a short &quot;SEO&quot; summary on Twitter cards etc.</FormDescription>
-                    <Textarea {...field} value={field.value?.toString()} />
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={form.control}
-                name="socialImage"
-                render={({ field }) => (
-                  <FormItem className="px-5">
-                    <FormLabel>Social Image</FormLabel>
-                    <FormDescription>Used as a preview image on Twitter cards etc.</FormDescription>
-                    {currentSocialImage && (
-                      <img
-                        alt={`social image preview for ${article.title}`}
-                        width={1200 / 2}
-                        height={630 / 2}
-                        className="aspect-[1200/630] rounded-md border"
-                        src={currentSocialImage.toString()}
-                      />
+        <Button
+          onClick={(e) => {
+            onSubmit(formValues)
+          }}
+          type="button"
+          variant="default"
+          size="sm"
+          className="h-7 disabled:cursor-wait"
+          disabled={updateArticleStatus === 'loading'}
+        >
+          Save
+        </Button>
+      </div>
+      <ResizablePanelGroup direction="horizontal" className="!flex-col border-t md:!flex-row">
+        <ResizablePanel
+          className="min-h-[var(--pane-layout-height)] md:min-h-full"
+          minSize={5}
+          defaultSize={20}
+          maxSize={35}
+        >
+          <Form {...form}>
+            <form
+              className="min-h-[280px] min-w-[280px]"
+              onSubmit={form.handleSubmit(onSubmit, (error) => {
+                console.log({ error })
+              })}
+            >
+              <ScrollArea className="h-[var(--pane-layout-height)] overflow-y-auto">
+                <div className="flex flex-col gap-5 py-5">
+                  <FormField
+                    control={form.control}
+                    name="title"
+                    render={({ field }) => (
+                      <FormItem className="px-5">
+                        <FormLabel>Title</FormLabel>
+                        <FormDescription>
+                          A title should summarize the tip and explain what it is about clearly.
+                        </FormDescription>
+                        <Input {...field} />
+                        <FormMessage />
+                      </FormItem>
                     )}
-                    <div className="flex items-center gap-1">
-                      <Input {...field} value={field.value?.toString()} type="hidden" />
-                    </div>
-                  </FormItem>
-                )}
-              />
-            </div>
-            <div className="col-span-6 flex w-full flex-col justify-start space-y-5 border-r md:h-full">
-              <FormField
-                control={form.control}
-                name="body"
-                render={({ field }) => (
-                  <FormItem className="pt-5">
-                    <FormLabel className="px-5 text-lg font-bold">Content</FormLabel>
-                    <CodemirrorEditor
-                      roomName={`${article._id}`}
-                      value={article.body || ''}
-                      onChange={async (data) => {
-                        form.setValue('body', data)
-                        await generateFeedback({
-                          resourceId: article._id,
-                          body: data,
-                          currentFeedback: feedbackMarkers,
-                        })
-                      }}
-                      markers={feedbackMarkers}
-                    />
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <div>
-                <ul>
-                  {feedbackMarkers.map((marker) => {
-                    return (
-                      <li
-                        key={marker.originalText}
-                      >{`${marker.level}: ${marker.originalText} -> ${marker.fullSuggestedChange} [${marker.feedback}]`}</li>
-                    )
-                  })}
-                </ul>
-              </div>
-            </div>
-            <div className="col-span-3">
-              {watcher && activeToolbarTab.id === 'assistant' && (
-                <ArticleAssistant article={{ ...article, ...formValues }} currentFeedback={feedbackMarkers} />
-              )}
-              {activeToolbarTab.id === 'media' && (
-                <>
-                  <CloudinaryUploadWidget dir={article._type} id={article._id} />
-                  <CloudinaryMediaBrowser />
-                </>
-              )}
-            </div>
-          </div>
-          <div className="bg-muted relative border-l">
-            <div className="flex flex-col gap-1 p-1">
-              <TooltipProvider delayDuration={0}>
-                {Array.from(TOOLBAR).map((item) => (
-                  <Tooltip key={item.id}>
-                    <TooltipTrigger asChild>
-                      <Button
-                        variant="link"
-                        type="button"
-                        className={cn(
-                          `hover:bg-background/50 flex aspect-square items-center justify-center rounded-lg border p-0 transition`,
-                          {
-                            'border-border bg-background': activeToolbarTab.id === item.id,
-                            'border-transparent bg-transparent': activeToolbarTab.id !== item.id,
-                          },
+                  />
+                  <FormField
+                    control={form.control}
+                    name="slug"
+                    render={({ field }) => (
+                      <FormItem className="px-5">
+                        <FormLabel>Slug</FormLabel>
+                        <Input {...field} />
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="visibility"
+                    render={({ field }) => (
+                      <FormItem className="px-5">
+                        <FormLabel>Visibility</FormLabel>
+                        <Select onValueChange={field.onChange} defaultValue={field.value}>
+                          <FormControl>
+                            <SelectTrigger>
+                              <SelectValue placeholder="Choose state" />
+                            </SelectTrigger>
+                          </FormControl>
+                          <SelectContent className="">
+                            {ArticleVisibilitySchema.options.map((option) => {
+                              const value = option._def.value
+                              return (
+                                <SelectItem key={value} value={value}>
+                                  {value}
+                                </SelectItem>
+                              )
+                            })}
+                          </SelectContent>
+                        </Select>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="state"
+                    render={({ field }) => (
+                      <FormItem className="px-5">
+                        <FormLabel>State</FormLabel>
+                        <Input {...field} readOnly disabled />
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="description"
+                    render={({ field }) => (
+                      <FormItem className="px-5">
+                        <FormLabel>Short Description</FormLabel>
+                        <FormDescription>Used as a short &quot;SEO&quot; summary on Twitter cards etc.</FormDescription>
+                        <Textarea {...field} value={field.value?.toString()} />
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="socialImage"
+                    render={({ field }) => (
+                      <FormItem className="px-5">
+                        <FormLabel>Social Image</FormLabel>
+                        <FormDescription>Used as a preview image on Twitter cards etc.</FormDescription>
+                        {currentSocialImage && (
+                          <img
+                            alt={`social image preview for ${article.title}`}
+                            width={1200 / 2}
+                            height={630 / 2}
+                            className="aspect-[1200/630] rounded-md border"
+                            src={currentSocialImage.toString()}
+                          />
                         )}
-                        onClick={() => setActiveToolbarTab(item)}
-                      >
-                        {item.icon()}
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent side="left" className="capitalize">
-                      {item.id}
-                    </TooltipContent>
-                  </Tooltip>
-                ))}
-              </TooltipProvider>
+                        <div className="flex items-center gap-1">
+                          <Input {...field} value={field.value?.toString()} type="hidden" />
+                        </div>
+                      </FormItem>
+                    )}
+                  />
+                </div>
+              </ScrollArea>
+            </form>
+          </Form>
+        </ResizablePanel>
+        <ResizableHandle />
+        <ResizablePanel defaultSize={50} className="min-h-[var(--pane-layout-height)] md:min-h-full">
+          <ScrollArea className="flex h-[var(--pane-layout-height)] w-full flex-col justify-start overflow-y-auto">
+            <CodemirrorEditor
+              roomName={`${article._id}`}
+              value={article.body || ''}
+              onChange={async (data) => {
+                form.setValue('body', data)
+                await generateFeedback({
+                  resourceId: article._id,
+                  body: data,
+                  currentFeedback: feedbackMarkers,
+                })
+              }}
+              markers={feedbackMarkers}
+            />
+            {/* <FormMessage /> */}
+            <div>
+              <ul>
+                {feedbackMarkers.map((marker) => {
+                  return (
+                    <li
+                      key={marker.originalText}
+                    >{`${marker.level}: ${marker.originalText} -> ${marker.fullSuggestedChange} [${marker.feedback}]`}</li>
+                  )
+                })}
+              </ul>
             </div>
+          </ScrollArea>
+        </ResizablePanel>
+        <ResizableHandle />
+        <ResizablePanel
+          className="h-[var(--pane-layout-height)] min-h-[var(--pane-layout-height)] md:min-h-full"
+          minSize={15}
+          defaultSize={25}
+          maxSize={50}
+        >
+          {watcher && activeToolbarTab.id === 'assistant' && (
+            <ArticleAssistant article={{ ...article, ...formValues }} currentFeedback={feedbackMarkers} />
+          )}
+          {activeToolbarTab.id === 'media' && (
+            <ScrollArea className="h-[var(--pane-layout-height)] overflow-y-auto">
+              <CloudinaryUploadWidget dir={article._type} id={article._id} />
+              <CloudinaryMediaBrowser />
+            </ScrollArea>
+          )}
+        </ResizablePanel>
+        <div className="bg-muted h-12 w-full md:h-[var(--pane-layout-height)] md:w-12 md:border-l">
+          <div className="flex flex-row gap-1 p-1 md:flex-col">
+            <TooltipProvider delayDuration={0}>
+              {Array.from(TOOLBAR).map((item) => (
+                <Tooltip key={item.id}>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="link"
+                      type="button"
+                      className={cn(
+                        `hover:bg-background/50 flex aspect-square items-center justify-center rounded-lg border p-0 transition`,
+                        {
+                          'border-border bg-background': activeToolbarTab.id === item.id,
+                          'border-transparent bg-transparent': activeToolbarTab.id !== item.id,
+                        },
+                      )}
+                      onClick={() => setActiveToolbarTab(item)}
+                    >
+                      {item.icon()}
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent side="left" className="capitalize">
+                    {item.id}
+                  </TooltipContent>
+                </Tooltip>
+              ))}
+            </TooltipProvider>
           </div>
         </div>
-      </form>
-    </Form>
+      </ResizablePanelGroup>
+    </>
   )
 }
 

--- a/apps/course-builder-web/src/app/layout.tsx
+++ b/apps/course-builder-web/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { Party } from '@/app/_components/party'
 import { Providers } from '@/app/_components/providers'
 import { ourFileRouter } from '@/app/api/uploadthing/core'
 import Navigation from '@/components/navigation'
+import { ThemeProvider } from '@/components/theme-provider'
 import { TRPCReactProvider } from '@/trpc/react'
 import { NextSSRPlugin } from '@uploadthing/react/next-ssr-plugin'
 import { AxiomWebVitals } from 'next-axiom'
@@ -31,21 +32,23 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <body className={`font-sans ${inter.variable}`}>
           <TRPCReactProvider>
             <Party />
-            <div key="1" className="flex min-h-screen w-full flex-col">
-              <Navigation />
-              <main className="flex min-h-[calc(100vh-var(--nav-height))] flex-col">
-                <NextSSRPlugin
-                  /**
-                   * The `extractRouterConfig` will extract **only** the route configs from the
-                   * router to prevent additional information from being leaked to the client. The
-                   * data passed to the client is the same as if you were to fetch
-                   * `/api/uploadthing` directly.
-                   */
-                  routerConfig={extractRouterConfig(ourFileRouter)}
-                />
-                {children}
-              </main>
-            </div>
+            <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
+              <div key="1" className="flex min-h-screen w-full flex-col">
+                <Navigation />
+                <main className="flex min-h-[calc(100vh-var(--nav-height))] flex-col">
+                  <NextSSRPlugin
+                    /**
+                     * The `extractRouterConfig` will extract **only** the route configs from the
+                     * router to prevent additional information from being leaked to the client. The
+                     * data passed to the client is the same as if you were to fetch
+                     * `/api/uploadthing` directly.
+                     */
+                    routerConfig={extractRouterConfig(ourFileRouter)}
+                  />
+                  {children}
+                </main>
+              </div>
+            </ThemeProvider>
           </TRPCReactProvider>
         </body>
       </html>

--- a/apps/course-builder-web/src/app/page.tsx
+++ b/apps/course-builder-web/src/app/page.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
 export default async function PlaygroundPage() {
   return (
     <main>
-      <article className="prose sm:prose-lg mx-auto w-full max-w-2xl px-5 py-8 sm:py-16">
+      <article className="prose sm:prose-lg dark:prose-invert mx-auto w-full max-w-2xl px-5 py-8 sm:py-16">
         <Landing />
       </article>
     </main>

--- a/apps/course-builder-web/src/app/tips/[slug]/edit/page.tsx
+++ b/apps/course-builder-web/src/app/tips/[slug]/edit/page.tsx
@@ -28,9 +28,5 @@ export default async function TipEditPage({ params }: { params: { slug: string }
 
   const reprocessForVideoResourceId = reprocessTranscript.bind(null, { videoResourceId: tip.videoResourceId })
 
-  return (
-    <div className="relative mx-auto flex h-full w-full flex-grow flex-col items-center justify-center">
-      <EditTipForm key={tip.slug} tip={tip} videoResourceLoader={videoResourceLoader} />
-    </div>
-  )
+  return <EditTipForm key={tip.slug} tip={tip} videoResourceLoader={videoResourceLoader} />
 }

--- a/apps/course-builder-web/src/app/tips/_components/cloudinary-media-browser.tsx
+++ b/apps/course-builder-web/src/app/tips/_components/cloudinary-media-browser.tsx
@@ -23,7 +23,7 @@ export const CloudinaryMediaBrowser = () => {
   return (
     <div>
       <h3 className="inline-flex px-5 text-lg font-bold">Media Browser</h3>
-      <div className="grid grid-cols-3 gap-1 p-2">
+      <div className="grid grid-cols-3 gap-1 px-5">
         {images.map((asset) => {
           return asset?.url ? (
             <div

--- a/apps/course-builder-web/src/components/navigation.tsx
+++ b/apps/course-builder-web/src/components/navigation.tsx
@@ -14,7 +14,7 @@ const Navigation: React.FC<NavigationProps> = async ({ className, size = 'md', n
     <>
       <div
         className={cn(
-          `bg-background relative z-50 flex h-[var(--nav-height)] w-full flex-col items-center justify-center border-b print:hidden`,
+          `bg-background relative z-50 flex h-[calc(var(--nav-height)-1px)] w-full flex-col items-center justify-center border-b print:hidden`,
           navigationContainerClassName,
         )}
       >

--- a/apps/course-builder-web/src/components/navigation/links.tsx
+++ b/apps/course-builder-web/src/components/navigation/links.tsx
@@ -9,6 +9,8 @@ import { cn } from '@/lib/utils'
 import { cx } from 'class-variance-authority'
 import { AnimatePresence, motion, useAnimationControls, type AnimationControls } from 'framer-motion'
 
+import { ThemeToggle } from './theme-toggle'
+
 export const getNavigationLinks = (): {
   label: string | React.JSX.Element
   href: string
@@ -82,9 +84,10 @@ export function Links({ className }: { className?: string }) {
           })}
         </div>
       </div>
-      <div className="flex items-center justify-end">
+      <div className="flex items-center justify-end gap-2">
         <Login className="hidden md:flex" />
         <User className="hidden md:flex" />
+        <ThemeToggle />
         <NavToggle isMenuOpened={menuOpen} setMenuOpened={setMenuOpen} />
       </div>
       <AnimatePresence>
@@ -97,7 +100,7 @@ export function Links({ className }: { className?: string }) {
               type: 'spring',
               duration: 0.5,
             }}
-            className="absolute left-0 top-0 flex w-full flex-col gap-2 border-b border-gray-100 bg-white px-2 pb-5 pt-16 text-2xl font-medium shadow-2xl shadow-black/20 backdrop-blur-md md:hidden"
+            className="bg-card absolute left-0 top-0 flex w-full flex-col gap-2 border-b px-2 pb-5 pt-16 text-2xl font-medium shadow-2xl shadow-black/20 backdrop-blur-md md:hidden"
           >
             {navigationLinks.map(({ label, href, icon }) => {
               return (
@@ -107,7 +110,7 @@ export function Links({ className }: { className?: string }) {
                   className="flex items-center gap-4 rounded-md px-3 py-2 transition hover:bg-indigo-300/10"
                   passHref
                 >
-                  <span className="flex w-5 items-center justify-center">{icon()}</span> {label}
+                  {label}
                 </Link>
               )
             })}
@@ -144,7 +147,7 @@ const NavToggle: React.FC<NavToggleProps> = ({ isMenuOpened, setMenuOpened, menu
 
   return (
     <button
-      className="absolute z-10 flex h-12 w-12 items-center justify-center p-1 md:hidden"
+      className="z-10 flex h-12 w-12 items-center justify-center p-1 md:hidden"
       onClick={async () => {
         // menuControls.start(isMenuOpened ? 'close' : 'open')
         setMenuOpened(!isMenuOpened)

--- a/apps/course-builder-web/src/components/navigation/theme-toggle.tsx
+++ b/apps/course-builder-web/src/components/navigation/theme-toggle.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import * as React from 'react'
+import { Moon, Sun } from 'lucide-react'
+import { useTheme } from 'next-themes'
+
+import { Button, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@coursebuilder/ui'
+
+export function ThemeToggle() {
+  const { setTheme } = useTheme()
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="icon">
+          <Sun className="h-4 w-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+          <Moon className="absolute h-4 w-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+          <span className="sr-only">Toggle theme</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={() => setTheme('light')}>Light</DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme('dark')}>Dark</DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme('system')}>System</DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/apps/course-builder-web/src/components/navigation/theme-toggle.tsx
+++ b/apps/course-builder-web/src/components/navigation/theme-toggle.tsx
@@ -12,7 +12,7 @@ export function ThemeToggle() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="icon">
+        <Button variant="ghost" size="icon" className="-mr-2">
           <Sun className="h-4 w-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
           <Moon className="absolute h-4 w-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
           <span className="sr-only">Toggle theme</span>

--- a/apps/course-builder-web/src/components/theme-provider.tsx
+++ b/apps/course-builder-web/src/components/theme-provider.tsx
@@ -1,0 +1,9 @@
+'use client'
+
+import * as React from 'react'
+import { ThemeProvider as NextThemesProvider } from 'next-themes'
+import { type ThemeProviderProps } from 'next-themes/dist/types'
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>
+}

--- a/apps/course-builder-web/src/styles/globals.css
+++ b/apps/course-builder-web/src/styles/globals.css
@@ -5,6 +5,8 @@
 @layer base {
   :root {
     --nav-height: 3.5rem;
+    --command-bar-height: 2.25rem;
+    --pane-layout-height: calc(100vh - var(--nav-height) - var(--command-bar-height));
 
     /* shadcnui */
 

--- a/packages/ui/index.tsx
+++ b/packages/ui/index.tsx
@@ -51,6 +51,7 @@ import { Input } from './primitives/input'
 import { Label } from './primitives/label'
 import { Popover, PopoverContent, PopoverTrigger } from './primitives/popover'
 import { Progress } from './primitives/progress'
+import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from './primitives/resizable'
 import { ScrollArea, ScrollBar } from './primitives/scroll-area'
 import {
   Select,
@@ -178,4 +179,7 @@ export {
   ToastTitle,
   ToastViewport,
   useToast,
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -37,6 +37,7 @@
     "react-day-picker": "^8.9.0",
     "react-dom": "canary",
     "react-hook-form": "^7.48.0",
+    "react-resizable-panels": "^2.0.9",
     "react-wrap-balancer": "^0.2.4",
     "tailwind-merge": "^1.14.0"
   },

--- a/packages/ui/primitives/resizable.tsx
+++ b/packages/ui/primitives/resizable.tsx
@@ -1,25 +1,27 @@
 'use client'
 
-import React from 'react'
+import * as React from 'react'
 import { GripVertical } from 'lucide-react'
 import * as ResizablePrimitive from 'react-resizable-panels'
 
 import { cn } from '../utils/cn'
 
-const ResizablePanelGroup: React.ComponentType<ResizablePrimitive.PanelGroupProps> = ({ className, ...props }) => (
+const ResizablePanelGroup = ({ className, ...props }: React.ComponentProps<typeof ResizablePrimitive.PanelGroup>) => (
   <ResizablePrimitive.PanelGroup
     className={cn('flex h-full w-full data-[panel-group-direction=vertical]:flex-col', className)}
     {...props}
   />
 )
 
-const ResizablePanel: React.ComponentType<ResizablePrimitive.PanelProps> = ResizablePrimitive.Panel
+const ResizablePanel = ResizablePrimitive.Panel
 
-type ResizableHandleProps = React.ComponentProps<typeof ResizablePrimitive.PanelResizeHandle> & {
+const ResizableHandle = ({
+  withHandle,
+  className,
+  ...props
+}: React.ComponentProps<typeof ResizablePrimitive.PanelResizeHandle> & {
   withHandle?: boolean
-}
-
-const ResizableHandle: React.FC<ResizableHandleProps> = ({ withHandle, className, ...props }) => (
+}) => (
   <ResizablePrimitive.PanelResizeHandle
     className={cn(
       'bg-border focus-visible:ring-ring relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-offset-1 data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:-translate-y-1/2 data-[panel-group-direction=vertical]:after:translate-x-0 [&[data-panel-group-direction=vertical]>div]:rotate-90',

--- a/packages/ui/primitives/resizable.tsx
+++ b/packages/ui/primitives/resizable.tsx
@@ -6,16 +6,18 @@ import * as ResizablePrimitive from 'react-resizable-panels'
 
 import { cn } from '../utils/cn'
 
-const ResizablePanelGroup = ({ className, ...props }: React.ComponentProps<typeof ResizablePrimitive.PanelGroup>) => (
+const ResizablePanelGroup: React.FC<
+  React.PropsWithChildren<{ direction: 'vertical' | 'horizontal'; className?: string }>
+> = ({ className, ...props }) => (
   <ResizablePrimitive.PanelGroup
     className={cn('flex h-full w-full data-[panel-group-direction=vertical]:flex-col', className)}
     {...props}
   />
 )
 
-const ResizablePanel = ResizablePrimitive.Panel
+const ResizablePanel: React.FC<ResizablePrimitive.PanelProps> = ResizablePrimitive.Panel
 
-const ResizableHandle = ({
+const ResizableHandle: React.FC<{ withHandle?: boolean; className?: string }> = ({
   withHandle,
   className,
   ...props

--- a/packages/ui/primitives/resizable.tsx
+++ b/packages/ui/primitives/resizable.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import React from 'react'
+import { GripVertical } from 'lucide-react'
+import * as ResizablePrimitive from 'react-resizable-panels'
+
+import { cn } from '../utils/cn'
+
+const ResizablePanelGroup: React.ComponentType<ResizablePrimitive.PanelGroupProps> = ({ className, ...props }) => (
+  <ResizablePrimitive.PanelGroup
+    className={cn('flex h-full w-full data-[panel-group-direction=vertical]:flex-col', className)}
+    {...props}
+  />
+)
+
+const ResizablePanel: React.ComponentType<ResizablePrimitive.PanelProps> = ResizablePrimitive.Panel
+
+type ResizableHandleProps = React.ComponentProps<typeof ResizablePrimitive.PanelResizeHandle> & {
+  withHandle?: boolean
+}
+
+const ResizableHandle: React.FC<ResizableHandleProps> = ({ withHandle, className, ...props }) => (
+  <ResizablePrimitive.PanelResizeHandle
+    className={cn(
+      'bg-border focus-visible:ring-ring relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-offset-1 data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:-translate-y-1/2 data-[panel-group-direction=vertical]:after:translate-x-0 [&[data-panel-group-direction=vertical]>div]:rotate-90',
+      className,
+    )}
+    {...props}
+  >
+    {withHandle && (
+      <div className="bg-border z-10 flex h-4 w-3 items-center justify-center rounded-sm border">
+        <GripVertical className="h-2.5 w-2.5" />
+      </div>
+    )}
+  </ResizablePrimitive.PanelResizeHandle>
+)
+
+export { ResizablePanelGroup, ResizablePanel, ResizableHandle }

--- a/packages/ui/primitives/resizable.tsx
+++ b/packages/ui/primitives/resizable.tsx
@@ -15,15 +15,9 @@ const ResizablePanelGroup: React.FC<
   />
 )
 
-const ResizablePanel: React.FC<ResizablePrimitive.PanelProps> = ResizablePrimitive.Panel
+const ResizablePanel: React.FC<ResizablePrimitive.PanelProps> = (props) => <ResizablePrimitive.Panel {...props} />
 
-const ResizableHandle: React.FC<{ withHandle?: boolean; className?: string }> = ({
-  withHandle,
-  className,
-  ...props
-}: React.ComponentProps<typeof ResizablePrimitive.PanelResizeHandle> & {
-  withHandle?: boolean
-}) => (
+const ResizableHandle: React.FC<any & { withHandle?: boolean }> = ({ withHandle, className, ...props }) => (
   <ResizablePrimitive.PanelResizeHandle
     className={cn(
       'bg-border focus-visible:ring-ring relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-offset-1 data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:-translate-y-1/2 data-[panel-group-direction=vertical]:after:translate-x-0 [&[data-panel-group-direction=vertical]>div]:rotate-90',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -422,6 +422,9 @@ importers:
       react-markdown:
         specifier: ^9.0.0
         version: 9.0.1(@types/react@18.2.55)(react@18.3.0-canary-03d6f7cf0-20240209)
+      react-resizable-panels:
+        specifier: ^2.0.9
+        version: 2.0.9(react-dom@18.3.0-canary-03d6f7cf0-20240209)(react@18.3.0-canary-03d6f7cf0-20240209)
       resend:
         specifier: ^3.2.0
         version: 3.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -386,6 +386,9 @@ importers:
       next-mdx-remote:
         specifier: ^4.4.1
         version: 4.4.1(react-dom@18.3.0-canary-03d6f7cf0-20240209)(react@18.3.0-canary-03d6f7cf0-20240209)
+      next-themes:
+        specifier: ^0.2.1
+        version: 0.2.1(next@14.1.1-canary.26)(react-dom@18.3.0-canary-03d6f7cf0-20240209)(react@18.3.0-canary-03d6f7cf0-20240209)
       npm:
         specifier: ^10.2.1
         version: 10.2.3
@@ -881,6 +884,9 @@ importers:
       react-hook-form:
         specifier: ^7.48.0
         version: 7.48.2(react@18.3.0-canary-03d6f7cf0-20240209)
+      react-resizable-panels:
+        specifier: ^2.0.9
+        version: 2.0.9(react-dom@18.3.0-canary-03d6f7cf0-20240209)(react@18.3.0-canary-03d6f7cf0-20240209)
       react-wrap-balancer:
         specifier: ^0.2.4
         version: 0.2.4(react@18.3.0-canary-03d6f7cf0-20240209)
@@ -11475,6 +11481,7 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
     dev: false
+    bundledDependencies: false
 
   /crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
@@ -17615,6 +17622,18 @@ packages:
       - supports-color
     dev: false
 
+  /next-themes@0.2.1(next@14.1.1-canary.26)(react-dom@18.3.0-canary-03d6f7cf0-20240209)(react@18.3.0-canary-03d6f7cf0-20240209):
+    resolution: {integrity: sha512-B+AKNfYNIzh0vqQQKqQItTS8evEouKD7H5Hj3kmuPERwddR2TxvDSFZuTj6T7Jfn1oyeUyJMydPl1Bkxkh0W7A==}
+    peerDependencies:
+      next: '*'
+      react: '*'
+      react-dom: '*'
+    dependencies:
+      next: 14.1.1-canary.26(@babel/core@7.23.3)(react-dom@18.3.0-canary-03d6f7cf0-20240209)(react@18.3.0-canary-03d6f7cf0-20240209)
+      react: 18.3.0-canary-03d6f7cf0-20240209
+      react-dom: 18.3.0-canary-03d6f7cf0-20240209(react@18.3.0-canary-03d6f7cf0-20240209)
+    dev: false
+
   /next-tick@1.1.0:
     resolution: {integrity: sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==}
     dev: true
@@ -19321,6 +19340,16 @@ packages:
       tslib: 2.6.2
       use-callback-ref: 1.3.0(@types/react@18.2.55)(react@18.3.0-canary-03d6f7cf0-20240209)
       use-sidecar: 1.1.2(@types/react@18.2.55)(react@18.3.0-canary-03d6f7cf0-20240209)
+    dev: false
+
+  /react-resizable-panels@2.0.9(react-dom@18.3.0-canary-03d6f7cf0-20240209)(react@18.3.0-canary-03d6f7cf0-20240209):
+    resolution: {integrity: sha512-ZylBvs7oG7Y/INWw3oYGolqgpFvoPW8MPeg9l1fURDeKpxrmUuCHBUmPj47BdZ11MODImu3kZYXG85rbySab7w==}
+    peerDependencies:
+      react: ^16.14.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.14.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 18.3.0-canary-03d6f7cf0-20240209
+      react-dom: 18.3.0-canary-03d6f7cf0-20240209(react@18.3.0-canary-03d6f7cf0-20240209)
     dev: false
 
   /react-rx@2.1.3(react@18.3.0-canary-03d6f7cf0-20240209)(rxjs@7.8.1):


### PR DESCRIPTION
- implemented [Resizable](https://ui.shadcn.com/docs/components/resizable) panes
  - to consider: store size values 
- consolidated edit routes layout and added [ScrollAreas](https://ui.shadcn.com/docs/components/scroll-area)
- minor refactor of tip and article edit forms, changed `form` wrapper so that multiple form elements can coexist
- added theme provider and toggle

https://github.com/badass-courses/course-builder/assets/25487857/4709f17b-b4ae-4ddf-9a5a-b4c264db8a6b

<img src="https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExdmVxazRwZGQ5NGN1OWl1bTFyYmpka25jajNhMjF1Zm91djFubHVqdSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/1JbkfY6fffRFC/giphy.gif" width="200" alt="gif">