### PR TITLE
feat: content metadata to represent content pieces

### DIFF
--- a/apps/course-builder-web/src/server/db/schema.ts
+++ b/apps/course-builder-web/src/server/db/schema.ts
@@ -203,8 +203,8 @@ export const rolePermissionsRelations = relations(rolePermissions, ({ one }) => 
 
 export const contentStates = mysqlTable('contentState', {
   id: varchar('id', { length: 255 }).notNull().primaryKey(),
-  slug: varchar('name', { length: 255 }).notNull().unique(),
-  title: varchar('name', { length: 255 }).notNull(),
+  slug: varchar('slug', { length: 255 }).notNull().unique(),
+  name: varchar('name', { length: 255 }).notNull(),
   description: text('description'),
   active: boolean('active').notNull().default(true),
   createdAt: timestamp('createdAt', {
@@ -223,8 +223,8 @@ export const contentStates = mysqlTable('contentState', {
 
 export const contentVisibilities = mysqlTable('contentVisibility', {
   id: varchar('id', { length: 255 }).notNull().primaryKey(),
-  slug: varchar('name', { length: 255 }).notNull().unique(),
-  title: varchar('name', { length: 255 }).notNull(),
+  slug: varchar('slug', { length: 255 }).notNull().unique(),
+  name: varchar('name', { length: 255 }).notNull(),
   description: text('description'),
   active: boolean('active').notNull().default(true),
   createdAt: timestamp('createdAt', {
@@ -272,8 +272,8 @@ export const contentContributionRelations = relations(contentContributions, ({ o
 
 export const contributionTypes = mysqlTable('contributionType', {
   id: varchar('id', { length: 255 }).notNull().primaryKey(),
-  slug: varchar('name', { length: 255 }).notNull().unique(),
-  title: varchar('name', { length: 255 }).notNull(),
+  slug: varchar('slug', { length: 255 }).notNull().unique(),
+  name: varchar('name', { length: 255 }).notNull(),
   description: text('description'),
   active: boolean('active').notNull().default(true),
   createdAt: timestamp('createdAt', {
@@ -298,7 +298,7 @@ export const contentMetadata = mysqlTable(
   'contentMetadata',
   {
     id: varchar('id', { length: 255 }).notNull().primaryKey(),
-    slug: varchar('name', { length: 255 }).notNull().unique(),
+    slug: varchar('slug', { length: 255 }).notNull().unique(),
     createdById: varchar('createdById', { length: 255 }).notNull(),
     title: varchar('title', { length: 255 }).notNull(),
     stateId: varchar('stateId', { length: 255 }).notNull(),

--- a/apps/course-builder-web/src/server/db/schema.ts
+++ b/apps/course-builder-web/src/server/db/schema.ts
@@ -4,6 +4,7 @@ import {
   boolean,
   index,
   int,
+  json,
   mysqlEnum,
   mysqlTableCreator,
   primaryKey,
@@ -27,7 +28,7 @@ export const users = mysqlTable(
     id: varchar('id', { length: 255 }).notNull().primaryKey(),
     name: varchar('name', { length: 255 }),
     role: mysqlEnum('role', ['user', 'admin']).default('user'),
-    email: varchar('email', { length: 255 }).notNull(),
+    email: varchar('email', { length: 255 }).notNull().unique(),
     emailVerified: timestamp('emailVerified', {
       mode: 'date',
       fsp: 3,
@@ -47,6 +48,293 @@ export const users = mysqlTable(
 export const usersRelations = relations(users, ({ many }) => ({
   accounts: many(accounts),
   communicationPreferences: many(communicationPreferences),
+  userRoles: many(userRoles),
+  userPermissions: many(userPermissions),
+  contributions: many(contentContributions),
+  createdContent: many(contentMetadata),
+}))
+
+export const permissions = mysqlTable('permission', {
+  id: varchar('id', { length: 255 }).notNull().primaryKey(),
+  name: varchar('name', { length: 255 }).notNull().unique(),
+  description: text('description'),
+  active: boolean('active').notNull().default(true),
+  createdAt: timestamp('createdAt', {
+    mode: 'date',
+    fsp: 3,
+  }).default(sql`CURRENT_TIMESTAMP(3)`),
+  updatedAt: timestamp('updatedAt', {
+    mode: 'date',
+    fsp: 3,
+  }),
+  deletedAt: timestamp('deletedAt', {
+    mode: 'date',
+    fsp: 3,
+  }),
+})
+
+export const permissionsRelations = relations(permissions, ({ many }) => ({
+  userRoles: many(userRoles),
+  rolePermissions: many(rolePermissions),
+}))
+
+export const roles = mysqlTable(
+  'role',
+  {
+    id: varchar('id', { length: 255 }).notNull().primaryKey(),
+    name: varchar('name', { length: 255 }).notNull().unique(),
+    description: text('description'),
+    active: boolean('active').notNull().default(true),
+    createdAt: timestamp('createdAt', {
+      mode: 'date',
+      fsp: 3,
+    }).default(sql`CURRENT_TIMESTAMP(3)`),
+    updatedAt: timestamp('updatedAt', {
+      mode: 'date',
+      fsp: 3,
+    }),
+    deletedAt: timestamp('deletedAt', {
+      mode: 'date',
+      fsp: 3,
+    }),
+  },
+  (role) => ({
+    nameIdx: index('name_idx').on(role.name),
+  }),
+)
+
+export const rolesRelations = relations(roles, ({ many }) => ({
+  userRoles: many(userRoles),
+  permissions: many(permissions),
+}))
+
+export const userRoles = mysqlTable(
+  'userRole',
+  {
+    userId: varchar('userId', { length: 255 }).notNull(),
+    roleId: varchar('roleId', { length: 255 }).notNull(),
+    active: boolean('active').notNull().default(true),
+    createdAt: timestamp('createdAt', {
+      mode: 'date',
+      fsp: 3,
+    }).default(sql`CURRENT_TIMESTAMP(3)`),
+    updatedAt: timestamp('updatedAt', {
+      mode: 'date',
+      fsp: 3,
+    }),
+    deletedAt: timestamp('deletedAt', {
+      mode: 'date',
+      fsp: 3,
+    }),
+  },
+  (ur) => ({
+    compoundKey: primaryKey({ columns: [ur.userId, ur.roleId] }),
+  }),
+)
+
+export const userRolesRelations = relations(userRoles, ({ one }) => ({
+  user: one(users, { fields: [userRoles.userId], references: [users.id] }),
+  role: one(roles, { fields: [userRoles.roleId], references: [roles.id] }),
+}))
+
+export const userPermissions = mysqlTable(
+  'userPermission',
+  {
+    userId: varchar('userId', { length: 255 }).notNull(),
+    permissionId: varchar('permissionId', { length: 255 }).notNull(),
+    active: boolean('active').notNull().default(true),
+    createdAt: timestamp('createdAt', {
+      mode: 'date',
+      fsp: 3,
+    }).default(sql`CURRENT_TIMESTAMP(3)`),
+    updatedAt: timestamp('updatedAt', {
+      mode: 'date',
+      fsp: 3,
+    }),
+    deletedAt: timestamp('deletedAt', {
+      mode: 'date',
+      fsp: 3,
+    }),
+  },
+  (up) => ({
+    compoundKey: primaryKey({ columns: [up.userId, up.permissionId] }),
+  }),
+)
+
+export const userPermissionsRelations = relations(userPermissions, ({ one }) => ({
+  user: one(users, { fields: [userPermissions.userId], references: [users.id] }),
+  permission: one(permissions, {
+    fields: [userPermissions.permissionId],
+    references: [permissions.id],
+  }),
+}))
+
+export const rolePermissions = mysqlTable(
+  'rolePermission',
+  {
+    roleId: varchar('roleId', { length: 255 }).notNull(),
+    permissionId: varchar('permissionId', { length: 255 }).notNull(),
+    active: boolean('active').notNull().default(true),
+    createdAt: timestamp('createdAt', {
+      mode: 'date',
+      fsp: 3,
+    }).default(sql`CURRENT_TIMESTAMP(3)`),
+    updatedAt: timestamp('updatedAt', {
+      mode: 'date',
+      fsp: 3,
+    }),
+    deletedAt: timestamp('deletedAt', {
+      mode: 'date',
+      fsp: 3,
+    }),
+  },
+  (rp) => ({
+    compoundKey: primaryKey({ columns: [rp.roleId, rp.permissionId] }),
+  }),
+)
+
+export const rolePermissionsRelations = relations(rolePermissions, ({ one }) => ({
+  role: one(roles, { fields: [rolePermissions.roleId], references: [roles.id] }),
+  permission: one(permissions, {
+    fields: [rolePermissions.permissionId],
+    references: [permissions.id],
+  }),
+}))
+
+export const contentStates = mysqlTable('contentState', {
+  id: varchar('id', { length: 255 }).notNull().primaryKey(),
+  slug: varchar('name', { length: 255 }).notNull().unique(),
+  title: varchar('name', { length: 255 }).notNull(),
+  description: text('description'),
+  active: boolean('active').notNull().default(true),
+  createdAt: timestamp('createdAt', {
+    mode: 'date',
+    fsp: 3,
+  }).default(sql`CURRENT_TIMESTAMP(3)`),
+  updatedAt: timestamp('updatedAt', {
+    mode: 'date',
+    fsp: 3,
+  }),
+  deletedAt: timestamp('deletedAt', {
+    mode: 'date',
+    fsp: 3,
+  }),
+})
+
+export const contentVisibilities = mysqlTable('contentVisibility', {
+  id: varchar('id', { length: 255 }).notNull().primaryKey(),
+  slug: varchar('name', { length: 255 }).notNull().unique(),
+  title: varchar('name', { length: 255 }).notNull(),
+  description: text('description'),
+  active: boolean('active').notNull().default(true),
+  createdAt: timestamp('createdAt', {
+    mode: 'date',
+    fsp: 3,
+  }).default(sql`CURRENT_TIMESTAMP(3)`),
+  updatedAt: timestamp('updatedAt', {
+    mode: 'date',
+    fsp: 3,
+  }),
+  deletedAt: timestamp('deletedAt', {
+    mode: 'date',
+    fsp: 3,
+  }),
+})
+
+export const contentContributions = mysqlTable('contentContribution', {
+  id: varchar('id', { length: 255 }).notNull().primaryKey(),
+  userId: varchar('userId', { length: 255 }).notNull(),
+  contentId: varchar('contentId', { length: 255 }).notNull(),
+  contributionTypeId: varchar('contributionTypeId', { length: 255 }).notNull(),
+  active: boolean('active').notNull().default(true),
+  createdAt: timestamp('createdAt', {
+    mode: 'date',
+    fsp: 3,
+  }).default(sql`CURRENT_TIMESTAMP(3)`),
+  updatedAt: timestamp('updatedAt', {
+    mode: 'date',
+    fsp: 3,
+  }),
+  deletedAt: timestamp('deletedAt', {
+    mode: 'date',
+    fsp: 3,
+  }),
+})
+
+export const contentContributionRelations = relations(contentContributions, ({ one }) => ({
+  user: one(users, { fields: [contentContributions.userId], references: [users.id] }),
+  content: one(contentMetadata, { fields: [contentContributions.contentId], references: [contentMetadata.id] }),
+  contributionType: one(contributionTypes, {
+    fields: [contentContributions.contributionTypeId],
+    references: [contributionTypes.id],
+  }),
+}))
+
+export const contributionTypes = mysqlTable('contributionType', {
+  id: varchar('id', { length: 255 }).notNull().primaryKey(),
+  slug: varchar('name', { length: 255 }).notNull().unique(),
+  title: varchar('name', { length: 255 }).notNull(),
+  description: text('description'),
+  active: boolean('active').notNull().default(true),
+  createdAt: timestamp('createdAt', {
+    mode: 'date',
+    fsp: 3,
+  }).default(sql`CURRENT_TIMESTAMP(3)`),
+  updatedAt: timestamp('updatedAt', {
+    mode: 'date',
+    fsp: 3,
+  }),
+  deletedAt: timestamp('deletedAt', {
+    mode: 'date',
+    fsp: 3,
+  }),
+})
+
+export const contributionTypesRelations = relations(contributionTypes, ({ many }) => ({
+  contributions: many(contentContributions),
+}))
+
+export const contentMetadata = mysqlTable(
+  'contentMetadata',
+  {
+    id: varchar('id', { length: 255 }).notNull().primaryKey(),
+    slug: varchar('name', { length: 255 }).notNull().unique(),
+    createdById: varchar('createdById', { length: 255 }).notNull(),
+    title: varchar('title', { length: 255 }).notNull(),
+    stateId: varchar('stateId', { length: 255 }).notNull(),
+    visibilityId: varchar('visibilityId', { length: 255 }).notNull(),
+    body: text('body'),
+    resources: json('resources'),
+    createdAt: timestamp('createdAt', {
+      mode: 'date',
+      fsp: 3,
+    }).default(sql`CURRENT_TIMESTAMP(3)`),
+    updatedAt: timestamp('updatedAt', {
+      mode: 'date',
+      fsp: 3,
+    }),
+    deletedAt: timestamp('deletedAt', {
+      mode: 'date',
+      fsp: 3,
+    }),
+  },
+  (cm) => ({
+    titleIdx: index('title_idx').on(cm.title),
+    slugIdx: index('slug_idx').on(cm.slug),
+    createdByIdx: index('createdById_idx').on(cm.createdById),
+    stateIdx: index('stateId_idx').on(cm.stateId),
+    visibilityIdx: index('visibilityId_idx').on(cm.visibilityId),
+  }),
+)
+
+export const contentMetadataRelations = relations(contentMetadata, ({ one, many }) => ({
+  createdBy: one(users, { fields: [contentMetadata.createdById], references: [users.id] }),
+  state: one(contentStates, { fields: [contentMetadata.stateId], references: [contentStates.id] }),
+  visibility: one(contentVisibilities, {
+    fields: [contentMetadata.visibilityId],
+    references: [contentVisibilities.id],
+  }),
+  contributions: many(contentContributions),
 }))
 
 export const communicationPreferenceTypes = mysqlTable('communicationPreferenceType', {


### PR DESCRIPTION
one thing i think we might want to avoid is the detachment from "author/instructor" and the user and think about this model from the perspective of a single database where we have a user and a user profile

in sanity this would mean that an "author" is a pointer

another thing i've been considering is the idea of ownership versus authorship and how that affects the model. a resource is "owned by" a user or set of users, but the owners arent necessarily the authors
you've got a set of permissions for any given resource like read/write/managepublished collections (lessons, articles, etc) have sets of contributors (credits), which is different in practice than ownership. a contributor doesn't necessarily have ability to edit/manage the resource for instance.

so there is the ability to manipulate the resources AND the display of credit in the byline that's presented with the resource

i'm not stoked on the term "author" as it's very specific to media type by definition

little gpt sesh to get to this https://chat.openai.com/share/ba3beff6-497b-4bcb-bed6-e93e3412fb0d

One interesting bit is the content_metadata table as a "sanity bridge". Using JSON table makes a ton of sense to me and opens up the possibility of user defined schemas for content types. roles, permissions, content, contribution, etc... all the "types" move to their own tables so they can be defined per-database so we aren't stuck using "tips" etc for every site and they can be shaped accordingly as needed.

![content is king](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExMWNzbmdtZnptcXhiZW95aHRzZDJ0MHRkNTFzbDdkbnQ5OGhiOGVuOSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/QLDzATIC59wffyP4Av/giphy.gif)