### PR TITLE
feat(vbd): add pricing widget to workshop module page

### DIFF
--- a/apps/value-based-design/src/app/(commerce)/products/[slug]/page.tsx
+++ b/apps/value-based-design/src/app/(commerce)/products/[slug]/page.tsx
@@ -115,7 +115,7 @@ async function ProductCommerce({
 	const product = await productLoader
 	console.log({ product })
 	if (!product) return null
-	const pricingDataLoader = getPricingData(product?.id)
+	const pricingDataLoader = getPricingData({ productId: product?.id })
 	let productProps: any
 
 	let commerceProps = await propsForCommerce({

--- a/apps/value-based-design/src/app/(content)/events/[slug]/page.tsx
+++ b/apps/value-based-design/src/app/(content)/events/[slug]/page.tsx
@@ -41,7 +41,7 @@ export default async function EventPage({
 
 	if (productParsed.success) {
 		product = productParsed.data
-		const pricingDataLoader = getPricingData(product?.id)
+		const pricingDataLoader = getPricingData({ productId: product?.id })
 
 		const commerceProps = await propsForCommerce({
 			query: {

--- a/apps/value-based-design/src/app/(content)/workshops/[module]/page.tsx
+++ b/apps/value-based-design/src/app/(content)/workshops/[module]/page.tsx
@@ -18,6 +18,7 @@ import type { ContentResource } from '@coursebuilder/core/types'
 import { Button } from '@coursebuilder/ui'
 
 import { TutorialLessonList } from '../_components/tutorial-lesson-list'
+import { WorkshopPricing } from '../_components/workshop-pricing-server'
 
 type Props = {
 	params: { module: string }
@@ -49,8 +50,8 @@ export async function generateMetadata(
 	}
 }
 
-export default async function ModulePage({ params }: Props) {
-	const { ability } = await getServerAuthSession()
+export default async function ModulePage({ params, searchParams }: Props) {
+	const { ability, session } = await getServerAuthSession()
 
 	if (!ability.can('read', 'Content')) {
 		redirect('/login')
@@ -124,6 +125,11 @@ export default async function ModulePage({ params }: Props) {
 					</article>
 				)}
 				<div className="flex w-full flex-col gap-3 sm:max-w-sm">
+					<WorkshopPricing
+						user={session?.user}
+						workshop={workshop}
+						searchParams={searchParams}
+					/>
 					<strong className="font-mono text-sm font-bold uppercase tracking-wide text-gray-700">
 						Contents
 					</strong>

--- a/apps/value-based-design/src/app/(content)/workshops/_components/pricing-widget.tsx
+++ b/apps/value-based-design/src/app/(content)/workshops/_components/pricing-widget.tsx
@@ -1,0 +1,61 @@
+import * as React from 'react'
+
+import { useCoupon } from '@coursebuilder/commerce-next/coupons/use-coupon'
+import * as Pricing from '@coursebuilder/commerce-next/pricing/pricing'
+import type { PricingOptions } from '@coursebuilder/commerce-next/pricing/pricing-props'
+import type { CommerceProps } from '@coursebuilder/commerce-next/utils/commerce-props'
+import { Product, Purchase } from '@coursebuilder/core/schemas'
+import type { FormattedPrice } from '@coursebuilder/core/types'
+
+export type PricingData = {
+	formattedPrice?: FormattedPrice | null
+	purchaseToUpgrade?: Purchase | null
+	quantityAvailable: number
+}
+
+export const PricingWidget: React.FC<{
+	product: Product
+	quantityAvailable: number
+	commerceProps: CommerceProps
+	pricingDataLoader: Promise<PricingData>
+	hasPurchasedCurrentProduct?: boolean
+	pricingWidgetOptions?: Partial<PricingOptions>
+}> = ({
+	product,
+	commerceProps,
+	pricingDataLoader,
+	pricingWidgetOptions,
+	quantityAvailable,
+}) => {
+	const couponFromCode = commerceProps?.couponFromCode
+	const { validCoupon } = useCoupon(couponFromCode)
+	const couponId =
+		commerceProps?.couponIdFromCoupon ||
+		(validCoupon ? couponFromCode?.id : undefined)
+
+	return (
+		<Pricing.Root
+			className="relative w-full"
+			product={product}
+			couponId={couponId}
+			options={pricingWidgetOptions}
+			userId={commerceProps?.userId}
+			pricingDataLoader={pricingDataLoader}
+		>
+			<Pricing.Product className="w-full">
+				<Pricing.ProductImage />
+				<Pricing.Details className="px-0">
+					<Pricing.Name />
+					<Pricing.LiveQuantity />
+					<Pricing.Price />
+					<Pricing.TeamToggle />
+					<Pricing.TeamQuantityInput />
+					<Pricing.BuyButton />
+					<Pricing.GuaranteeBadge />
+					<Pricing.LiveRefundPolicy />
+					<Pricing.PPPToggle />
+				</Pricing.Details>
+			</Pricing.Product>
+		</Pricing.Root>
+	)
+}

--- a/apps/value-based-design/src/app/(content)/workshops/_components/workshop-page-props.ts
+++ b/apps/value-based-design/src/app/(content)/workshops/_components/workshop-page-props.ts
@@ -1,0 +1,20 @@
+import { type Module } from '@/lib/module'
+import { MDXRemoteSerializeResult } from 'next-mdx-remote'
+
+import { PricingData } from '@coursebuilder/commerce-next/pricing/pricing-widget'
+import { CommerceProps } from '@coursebuilder/commerce-next/utils/commerce-props'
+import { Product, Purchase } from '@coursebuilder/core/schemas'
+
+export type WorkshopPageProps = {
+	workshop: Module
+	quantityAvailable: number
+	product?: Product
+	mdx?: MDXRemoteSerializeResult
+	hasPurchasedCurrentProduct?: boolean
+	availableBonuses: any[]
+	existingPurchase?: (Purchase & { product?: Product | null }) | null
+	purchases?: Purchase[]
+	purchasedProductIds?: string[]
+	userId?: string
+	pricingDataLoader: Promise<PricingData>
+} & CommerceProps

--- a/apps/value-based-design/src/app/(content)/workshops/_components/workshop-pricing-server.tsx
+++ b/apps/value-based-design/src/app/(content)/workshops/_components/workshop-pricing-server.tsx
@@ -1,0 +1,107 @@
+import * as React from 'react'
+import { courseBuilderAdapter } from '@/db'
+import { env } from '@/env.mjs'
+import { Module, ModuleSchema } from '@/lib/module'
+import { getPricingData } from '@/lib/pricing-query'
+import first from 'lodash/first'
+
+import { propsForCommerce } from '@coursebuilder/commerce-next/pricing/props-for-commerce'
+import {
+	productSchema,
+	type Product,
+	type Purchase,
+	type User,
+} from '@coursebuilder/core/schemas'
+
+import { type WorkshopPageProps } from './workshop-page-props'
+import { WorkshopPricing as WorkshopPricingClient } from './workshop-pricing'
+
+export async function WorkshopPricing({
+	user,
+	searchParams,
+	workshop,
+}: {
+	user?: User | null
+	searchParams: { [key: string]: string | string[] | undefined }
+	workshop: Module
+}) {
+	const productParsed = productSchema.safeParse(
+		first(workshop.resourceProducts)?.product,
+	)
+
+	let workshopProps: WorkshopPageProps
+	let product: Product | null = null
+
+	if (productParsed.success) {
+		product = productParsed.data
+
+		const pricingDataLoader = getPricingData({
+			productId: product.id,
+		})
+
+		const commerceProps = await propsForCommerce(
+			{
+				query: {
+					allowPurchase: 'true',
+					...searchParams,
+				},
+				userId: user?.id,
+				products: [productParsed.data],
+			},
+			courseBuilderAdapter,
+		)
+
+		const baseProps = {
+			workshop,
+			availableBonuses: [],
+			product,
+			pricingDataLoader,
+			quantityAvailable: product.quantityAvailable,
+			...commerceProps,
+		}
+
+		if (!user) {
+			workshopProps = baseProps
+		} else {
+			const purchaseForProduct = commerceProps.purchases?.find(
+				(purchase: Purchase) => {
+					return purchase.productId === productSchema.parse(product).id
+				},
+			)
+
+			if (!purchaseForProduct) {
+				workshopProps = baseProps
+			} else {
+				const { purchase, existingPurchase } =
+					await courseBuilderAdapter.getPurchaseDetails(
+						purchaseForProduct.id,
+						user.id,
+					)
+				const purchasedProductIds =
+					commerceProps?.purchases?.map((purchase) => purchase.productId) || []
+				workshopProps = {
+					...baseProps,
+					hasPurchasedCurrentProduct: Boolean(purchase),
+					existingPurchase,
+					quantityAvailable: product.quantityAvailable,
+					purchasedProductIds,
+				}
+			}
+		}
+	} else {
+		workshopProps = {
+			workshop,
+			availableBonuses: [],
+			quantityAvailable: -1,
+			pricingDataLoader: Promise.resolve({
+				formattedPrice: null,
+				purchaseToUpgrade: null,
+				quantityAvailable: -1,
+			}),
+		}
+	}
+
+	const canView = workshopProps.hasPurchasedCurrentProduct
+
+	return !canView ? <WorkshopPricingClient {...workshopProps} /> : null
+}

--- a/apps/value-based-design/src/app/(content)/workshops/_components/workshop-pricing.tsx
+++ b/apps/value-based-design/src/app/(content)/workshops/_components/workshop-pricing.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import * as React from 'react'
+import { env } from '@/env.mjs'
+
+import { PriceCheckProvider } from '@coursebuilder/commerce-next/pricing/pricing-check-context'
+
+import { PricingWidget } from './pricing-widget'
+import type { WorkshopPageProps } from './workshop-page-props'
+
+export function WorkshopPricing({
+	product,
+	quantityAvailable,
+	pricingDataLoader,
+	purchasedProductIds,
+	hasPurchasedCurrentProduct,
+	...commerceProps
+}: WorkshopPageProps) {
+	const teamQuantityLimit = 100
+
+	const cancelUrl = product
+		? `${env.NEXT_PUBLIC_URL}/workshops/${product.fields?.slug || product.id}`
+		: ''
+
+	return product ? (
+		<PriceCheckProvider purchasedProductIds={purchasedProductIds}>
+			<PricingWidget
+				commerceProps={{ ...commerceProps, products: [product] }}
+				hasPurchasedCurrentProduct={hasPurchasedCurrentProduct}
+				product={product}
+				quantityAvailable={quantityAvailable}
+				pricingDataLoader={pricingDataLoader}
+				pricingWidgetOptions={{
+					withImage: true,
+					withGuaranteeBadge: true,
+					isLiveEvent: false,
+					teamQuantityLimit,
+					isPPPEnabled: true,
+					cancelUrl: cancelUrl,
+				}}
+			/>
+		</PriceCheckProvider>
+	) : null
+}

--- a/apps/value-based-design/src/lib/module.ts
+++ b/apps/value-based-design/src/lib/module.ts
@@ -1,13 +1,29 @@
 import z from 'zod'
 
+import { productSchema } from '@coursebuilder/core/schemas'
+
 export const ModuleSchema = z.object({
 	type: z.enum(['tutorial', 'workshop']),
 	id: z.string(),
+	resourceProducts: z
+		.array(
+			z.object({
+				resourceId: z.string(),
+				productId: z.string(),
+				product: productSchema,
+			}),
+		)
+		.optional()
+		.nullable(),
 	fields: z.object({
 		slug: z.string(),
 		title: z.string().min(2).max(90),
 		body: z.string().optional().nullable(),
 		description: z.string().optional().nullable(),
+		github: z.string().optional().nullable(),
+		state: z
+			.enum(['draft', 'published', 'archived', 'deleted'])
+			.default('draft'),
 		visibility: z.union([
 			z.literal('public'),
 			z.literal('private'),

--- a/apps/value-based-design/src/lib/pricing-query.ts
+++ b/apps/value-based-design/src/lib/pricing-query.ts
@@ -4,7 +4,10 @@ import { eq } from 'drizzle-orm'
 
 import { formatPricesForProduct } from '@coursebuilder/core'
 import { Purchase } from '@coursebuilder/core/schemas'
-import { type FormattedPrice } from '@coursebuilder/core/types'
+import {
+	type FormatPricesForProductOptions,
+	type FormattedPrice,
+} from '@coursebuilder/core/types'
 
 export type PricingData = {
 	formattedPrice?: FormattedPrice | null
@@ -13,9 +16,9 @@ export type PricingData = {
 }
 
 export async function getPricingData(
-	productId?: string | null,
+	options: Partial<FormatPricesForProductOptions>,
 ): Promise<PricingData> {
-	if (!productId)
+	if (!options.productId)
 		return {
 			formattedPrice: null,
 			purchaseToUpgrade: null,
@@ -23,13 +26,13 @@ export async function getPricingData(
 		}
 
 	const formattedPrice = await formatPricesForProduct({
-		productId,
+		...options,
 		ctx: courseBuilderAdapter,
 	})
 
-	const product = await courseBuilderAdapter.getProduct(productId)
+	const product = await courseBuilderAdapter.getProduct(options.productId)
 	const totalPurchases = await db.query.purchases.findMany({
-		where: eq(purchases.productId, productId),
+		where: eq(purchases.productId, options.productId),
 	})
 
 	const purchaseToUpgrade = formattedPrice.upgradeFromPurchaseId

--- a/apps/value-based-design/src/lib/workshops-query.ts
+++ b/apps/value-based-design/src/lib/workshops-query.ts
@@ -40,20 +40,15 @@ export async function getWorkshop(moduleSlugOrId: string) {
 		),
 		with: {
 			resources: {
+				// sections and stand-alone top level resource join
 				with: {
 					resource: {
+						// section or resource
 						with: {
 							resources: {
+								// lessons in section join
 								with: {
-									resource: {
-										with: {
-											resources: {
-												with: {
-													resource: true,
-												},
-											},
-										},
-									},
+									resource: true, //lesson, no need for more (videos etc)
 								},
 								orderBy: asc(contentResourceResource.position),
 							},
@@ -61,6 +56,15 @@ export async function getWorkshop(moduleSlugOrId: string) {
 					},
 				},
 				orderBy: asc(contentResourceResource.position),
+			},
+			resourceProducts: {
+				with: {
+					product: {
+						with: {
+							price: true,
+						},
+					},
+				},
 			},
 		},
 	})


### PR DESCRIPTION
This adds the `PricingWidget` Vojta created for pro-nextjs to value based design. 

I went ahead and broke out all the pricing widget logic from the module page and added a `pricing-widget-server` component that handles that loading/logic so the module page imports the `PricingWidget` from `pricing-widget-server`. Felt cleaner to encapsulate that logic in a component rather than clogging up the module page

## workshop not purchased
![not purchased](https://github.com/user-attachments/assets/f1e4d415-5fd3-4b02-bb8e-faaa30fc1fa0)

## workshop purchased
![purchased](https://github.com/user-attachments/assets/a4413925-8a28-4a07-9587-50eac90a406d)


![gif](https://media3.giphy.com/media/AHu4KQJwXzbgs/giphy.gif?cid=1927fc1bsylxs82a2n9y2xbk69pwm8pkyfkyxci60prfedrs&ep=v1_gifs_search&rid=giphy.gif&ct=g)