### PR TITLE
feat(cb): handle stripe refund and dispute webhook events

### DIFF
--- a/packages/core/src/inngest/commerce/event-purchase-status-updated.ts
+++ b/packages/core/src/inngest/commerce/event-purchase-status-updated.ts
@@ -1,0 +1,55 @@
+import { NonRetriableError } from 'inngest'
+import { isEmpty } from 'lodash'
+import pluralize from 'pluralize'
+import { z } from 'zod'
+
+import {
+	CoreInngestFunctionInput,
+	CoreInngestHandler,
+	CoreInngestTrigger,
+} from '../create-inngest-middleware'
+
+export const PURCHASE_STATUS_UPDATED_EVENT = 'commerce/update-purchase-status'
+
+export type PurchaseStatusUpdated = {
+	name: typeof PURCHASE_STATUS_UPDATED_EVENT
+	data: PurchaseStatusUpdatedEvent
+}
+
+export type PurchaseStatusUpdatedEvent = z.infer<
+	typeof PurchaseStatusUpdatedEventSchema
+>
+
+export const PurchaseStatusUpdatedEventSchema = z.object({
+	stripeChargeId: z.string(),
+	status: z.enum(['Valid', 'Refunded', 'Disputed', 'Banned', 'Restricted']),
+})
+
+export const updatePurchaseStatusConfig = {
+	id: `update-purchase-status`,
+	name: 'Update Purchase Status',
+}
+export const updatePurchaseStatusTrigger: CoreInngestTrigger = {
+	event: PURCHASE_STATUS_UPDATED_EVENT,
+}
+
+export const updatePurchaseStatusHandler: CoreInngestHandler = async ({
+	event,
+	step,
+	db,
+	notificationProvider,
+	paymentProvider,
+}: CoreInngestFunctionInput) => {
+	return await step.run('update purchase status', async () => {
+		return db.updatePurchaseStatusForCharge(
+			event.data.stripeChargeId,
+			event.data.status,
+		)
+	})
+}
+
+export const updatePurchaseStatus = {
+	config: updatePurchaseStatusConfig,
+	trigger: updatePurchaseStatusTrigger,
+	handler: updatePurchaseStatusHandler,
+}

--- a/packages/core/src/inngest/index.ts
+++ b/packages/core/src/inngest/index.ts
@@ -7,6 +7,11 @@ import {
 	NEW_PURCHASE_CREATED_EVENT,
 	NewPurchaseCreated,
 } from './commerce/event-new-purchase-created'
+import {
+	PURCHASE_STATUS_UPDATED_EVENT,
+	PurchaseStatusUpdated,
+	updatePurchaseStatus,
+} from './commerce/event-purchase-status-updated'
 import { sendCreatorSlackNotification } from './commerce/send-creator-slack-notification'
 import { sendPostPurchaseEmail } from './commerce/send-post-purchase-email'
 import {
@@ -49,6 +54,7 @@ export type CourseBuilderCoreEvents = {
 	[MUX_WEBHOOK_EVENT]: EventVideoMuxWebhook
 	[RESOURCE_CHAT_REQUEST_EVENT]: ResourceChat
 	[STRIPE_CHECKOUT_SESSION_COMPLETED_EVENT]: StripeCheckoutSessionCompleted
+	[PURCHASE_STATUS_UPDATED_EVENT]: PurchaseStatusUpdated
 	[NEW_PURCHASE_CREATED_EVENT]: NewPurchaseCreated
 }
 
@@ -58,4 +64,5 @@ export const courseBuilderCoreFunctions = [
 	stripeCheckoutSessionComplete,
 	sendCreatorSlackNotification,
 	resourceChat,
+	updatePurchaseStatus,
 ]


### PR DESCRIPTION
This adds a `PURCHASE_STATUS_UPDATED_EVENT` that we can send to inngest with a charge Id (identifier which is different than the `merchantChargeId` we store on a purchase) and status. For the current use-case, this sends `Refunded` and `Disputed` status's when we receive `charge.refunded`  or `charge.dispute.created` webhook events from stripe.

The result is a purchase with it's status updated:
![image](https://github.com/user-attachments/assets/a03872d6-d49f-4997-a3be-4574daec026a)

![gif](https://media4.giphy.com/media/I1nwVpCaB4k36/giphy.gif?cid=1927fc1bn1f0ddxaeluh2z5rjv1v0r7q5n4ds1p2fg4c96n7&ep=v1_gifs_search&rid=giphy.gif&ct=g)
