### PR TITLE
feat(vbd): add ability rules and update tutorial lesson list

### DIFF
--- a/apps/value-based-design/src/ability/index.ts
+++ b/apps/value-based-design/src/ability/index.ts
@@ -1,5 +1,5 @@
-import { type Lesson } from '@/lib/lessons'
-import { type Module } from '@/lib/module'
+import { Lesson } from '@/lib/lessons'
+import { Module } from '@/lib/module'
 import {
 	AbilityBuilder,
 	createMongoAbility,
@@ -8,13 +8,38 @@ import {
 } from '@casl/ability'
 import z from 'zod'
 
-import { userSchema } from '@coursebuilder/core/schemas'
-import { type ContentResource } from '@coursebuilder/core/types'
+import { userSchema, type Purchase } from '@coursebuilder/core/schemas'
+import { ContentResourceResourceSchema } from '@coursebuilder/core/schemas/content-resource-schema'
+import { ContentResource } from '@coursebuilder/core/types'
 
-export type User = z.infer<typeof userSchema>
+import {
+	hasAvailableSeats,
+	hasBulkPurchase,
+	hasChargesForPurchases,
+} from './purchase-validators'
 
-type Actions = 'create' | 'read' | 'update' | 'delete' | 'manage' | 'view'
-type Subjects = 'Content' | 'User' | ContentResource | User | 'all' | 'Invoice'
+export const UserSchema = userSchema
+
+export type User = z.infer<typeof UserSchema>
+
+type Actions =
+	| 'create'
+	| 'read'
+	| 'update'
+	| 'delete'
+	| 'manage'
+	| 'view'
+	| 'invite'
+
+type Subjects =
+	| 'Content'
+	| 'User'
+	| ContentResource
+	| User
+	| 'all'
+	| 'Invoice'
+	| 'RegionRestriction'
+	| 'Team'
 
 export type AppAbility = MongoAbility<[Actions, Subjects]>
 
@@ -55,7 +80,7 @@ export function getAbilityRules(options: GetAbilityOptions = {}) {
 			can('manage', 'Content', { createdById: { $eq: options.user.id } })
 		}
 
-		can('read', 'User', { id: options.user.id })
+		can(['read', 'update'], 'User', { id: options.user.id })
 	}
 
 	can('read', 'Content', {
@@ -66,19 +91,6 @@ export function getAbilityRules(options: GetAbilityOptions = {}) {
 	return rules
 }
 
-/**
- * "compiled" ability generated from a bag of options passed in where the options determine what
- * `can` be performed as an ability
- *
- * any asynchronous logic should be handled in the construction of the options
- *
- * @see https://casl.js.org/v6/en/guide/intro
- * @param options
- */
-export function getAbility(options: GetAbilityOptions = {}) {
-	return createAppAbility(getAbilityRules(options))
-}
-
 type ViewerAbilityInput = {
 	user?: User | null
 	subscriber?: any
@@ -87,17 +99,14 @@ type ViewerAbilityInput = {
 	section?: ContentResource
 	isSolution?: boolean
 	country?: string
-	purchasedModules?: {
-		productId: string
-		modules: { _id: string; slug: string }[]
-	}[]
+	purchases?: Purchase[]
 }
 
 export function defineRulesForPurchases(
 	viewerAbilityInput: ViewerAbilityInput,
 ) {
 	const { can, rules } = new AbilityBuilder<AppAbility>(createMongoAbility)
-	const { user, country, purchasedModules = [], module } = viewerAbilityInput
+	const { user, country, purchases = [], module } = viewerAbilityInput
 
 	if (user) {
 		can('update', 'User', {
@@ -118,65 +127,59 @@ export function defineRulesForPurchases(
 		can(['read', 'update'], 'User', { id: user.id })
 	}
 
-	// if (user && module && purchasedModules) {
-	// 	const modulePurchase = purchasedModules
-	// 		.filter((purchasedModule) =>
-	// 			purchasedModule.modules.some((m) => m._id === module?._id),
-	// 		)
-	// 		.flatMap((purchasedModule) => {
-	// 			return user?.purchases?.filter(
-	// 				(purchase) => purchase.productId === purchasedModule.productId,
-	// 			)
-	// 		})
-	//
-	// 	const userHasPurchaseWithAccess = modulePurchase.map((purchase) => {
-	// 		if (purchase?.bulkCouponId !== null) {
-	// 			return {valid: false, reason: 'bulk_purchase'}
-	// 		}
-	//
-	// 		if (purchase.status === 'Restricted' && purchase.country !== country) {
-	// 			return {valid: false, reason: 'region_restricted'}
-	// 		}
-	//
-	// 		if (purchase.status === 'Restricted' && module.moduleType === 'bonus') {
-	// 			return {valid: false, reason: 'region_restricted'}
-	// 		}
-	//
-	// 		if (
-	// 			purchase.status === 'Valid' ||
-	// 			(purchase.status === 'Restricted' &&
-	// 				purchase.country === country &&
-	// 				module.moduleType !== 'bonus')
-	// 		) {
-	// 			return {valid: true}
-	// 		}
-	// 		return {valid: false, reason: 'unknown'}
-	// 	})
-	//
-	// 	if (userHasPurchaseWithAccess.some((purchase) => purchase.valid)) {
-	// 		can('view', 'Content')
-	// 	}
-	//
-	// 	if (
-	// 		userHasPurchaseWithAccess.some(
-	// 			(purchase) => purchase.reason === 'region_restricted',
-	// 		)
-	// 	) {
-	// 		can('view', 'RegionRestriction')
-	// 	}
-	// }
+	if (user && module?.resourceProducts && purchases) {
+		const modulePurchases = purchases.filter((purchase) =>
+			module?.resourceProducts?.some(
+				(product) => product.productId === purchase.productId,
+			),
+		)
 
-	// if (hasChargesForPurchases(user?.purchases)) {
-	// 	can('view', 'Invoice')
-	// }
-	//
-	// if (hasBulkPurchase(user?.purchases)) {
-	// 	can('view', 'Team')
-	// }
-	//
-	// if (hasAvailableSeats(user?.purchases)) {
-	// 	can('invite', 'Team')
-	// }
+		const userHasPurchaseWithAccess = modulePurchases.map((purchase) => {
+			if (purchase?.bulkCouponId !== null) {
+				return { valid: false, reason: 'bulk_purchase' }
+			}
+
+			if (purchase.status === 'Restricted' && purchase.country !== country) {
+				return { valid: false, reason: 'region_restricted' }
+			}
+
+			// if (purchase.status === 'Restricted' && module.type === 'bonus') {
+			// 	return { valid: false, reason: 'region_restricted' }
+			// }
+
+			if (
+				purchase.status === 'Valid' ||
+				(purchase.status === 'Restricted' && purchase.country === country) // && module.type !== 'bonus'
+			) {
+				return { valid: true }
+			}
+			return { valid: false, reason: 'unknown' }
+		})
+
+		if (userHasPurchaseWithAccess.some((purchase) => purchase.valid)) {
+			can('read', 'Content')
+		}
+
+		if (
+			userHasPurchaseWithAccess.some(
+				(purchase) => purchase.reason === 'region_restricted',
+			)
+		) {
+			can('read', 'RegionRestriction')
+		}
+	}
+
+	if (hasChargesForPurchases(purchases)) {
+		can('read', 'Invoice')
+	}
+
+	if (hasBulkPurchase(purchases)) {
+		can('read', 'Team')
+	}
+
+	if (hasAvailableSeats(purchases)) {
+		can('invite', 'Team')
+	}
 
 	if (isFreelyVisible(viewerAbilityInput)) {
 		can('read', 'Content')
@@ -244,4 +247,17 @@ const isFreelyVisible = ({
 		lesson.id === lessons?.[0]?.resourceId
 
 	return isFirstLesson && lesson && !isSolution
+}
+
+/**
+ * "compiled" ability generated from a bag of options passed in where the options determine what
+ * `can` be performed as an ability
+ *
+ * any asynchronous logic should be handled in the construction of the options
+ *
+ * @see https://casl.js.org/v6/en/guide/intro
+ * @param options
+ */
+export function getAbility(options: GetAbilityOptions = {}) {
+	return createAppAbility(getAbilityRules(options))
 }

--- a/apps/value-based-design/src/ability/purchase-validators.test.ts
+++ b/apps/value-based-design/src/ability/purchase-validators.test.ts
@@ -1,0 +1,97 @@
+import type { Coupon, Purchase } from '@coursebuilder/core/schemas'
+
+import {
+	bulkCouponHasSeats,
+	hasAvailableSeats,
+	hasBulkPurchase,
+	hasInvoice,
+	hasValidPurchase,
+} from './purchase-validators'
+
+test('coupon has seats left if used count less than maxUses', () => {
+	const coupon = {
+		maxUses: 1,
+		usedCount: 0,
+	} as Coupon
+	expect(bulkCouponHasSeats(coupon)).toBe(true)
+})
+
+test('coupon has no seats left if used count equal to maxUses', () => {
+	const coupon = {
+		maxUses: 1,
+		usedCount: 1,
+	} as Coupon
+	expect(bulkCouponHasSeats(coupon)).toBe(false)
+})
+
+test('coupon has no seats left if used count greater then maxUses', () => {
+	const coupon = {
+		maxUses: 1,
+		usedCount: 66,
+	} as Coupon
+	expect(bulkCouponHasSeats(coupon)).toBe(false)
+})
+
+// test hasAvailableSeats with jest
+test('has available seats if a purchase exists with a bulk coupon with seats', () => {
+	const purchases = [
+		{
+			bulkCoupon: {
+				maxUses: 1,
+				usedCount: 0,
+			},
+		},
+	] as Purchase[]
+	expect(hasAvailableSeats(purchases)).toBe(true)
+})
+
+test('has no available seats if a purchase exists with a bulk coupon without seats', () => {
+	const purchases = [
+		{
+			bulkCoupon: {
+				maxUses: 1,
+				usedCount: 2,
+			},
+		},
+	] as Purchase[]
+	expect(hasAvailableSeats(purchases)).toBe(false)
+})
+
+test('has a valid purchase', () => {
+	const purchases = [{}] as Purchase[]
+	expect(hasValidPurchase(purchases)).toBe(true)
+})
+
+test('has an invalid purchase because it has a bulk coupon', () => {
+	const purchases = [
+		{
+			bulkCoupon: {
+				maxUses: 1,
+				usedCount: 2,
+			},
+		},
+	] as Purchase[]
+	expect(hasValidPurchase(purchases)).toBe(false)
+})
+
+test('has a bulk purchase', () => {
+	const purchases = [
+		{},
+		{
+			bulkCoupon: {
+				maxUses: 1,
+				usedCount: 2,
+			},
+		},
+	] as Purchase[]
+	expect(hasBulkPurchase(purchases)).toBe(true)
+})
+
+test('hasInvoice', () => {
+	const purchases = [
+		{
+			merchantChargeId: '123',
+		},
+	] as Purchase[]
+	expect(hasInvoice(purchases)).toBe(true)
+})

--- a/apps/value-based-design/src/ability/purchase-validators.ts
+++ b/apps/value-based-design/src/ability/purchase-validators.ts
@@ -1,0 +1,35 @@
+import type { Purchase } from '@coursebuilder/core/schemas'
+
+export function bulkCouponHasSeats(coupon: Purchase['bulkCoupon']) {
+	return coupon && coupon.usedCount < coupon.maxUses
+}
+
+export function hasChargesForPurchases(purchases?: Purchase[]) {
+	return purchases?.some((purchase) => Boolean(purchase.merchantChargeId))
+}
+
+export function hasBulkPurchase(purchases?: Purchase[]) {
+	return purchases?.some((purchase) => Boolean(purchase.bulkCoupon))
+}
+
+export function hasAvailableSeats(purchases?: Purchase[]) {
+	return purchases?.some(
+		(purchase) =>
+			Boolean(purchase.bulkCoupon) && bulkCouponHasSeats(purchase.bulkCoupon),
+	)
+}
+
+export function hasValidPurchase(purchases?: Purchase[]) {
+	return purchases?.some((purchase) => {
+		return (
+			(purchase &&
+				!Boolean(purchase.bulkCoupon) &&
+				purchase.status === 'Valid') ||
+			purchase.status === 'Restricted'
+		)
+	})
+}
+
+export function hasInvoice(purchases?: Purchase[]) {
+	return purchases?.some((purchase) => Boolean(purchase.merchantChargeId))
+}

--- a/apps/value-based-design/src/app/(content)/workshops/_components/workshop-pricing-server.tsx
+++ b/apps/value-based-design/src/app/(content)/workshops/_components/workshop-pricing-server.tsx
@@ -81,7 +81,9 @@ export async function WorkshopPricing({
 					commerceProps?.purchases?.map((purchase) => purchase.productId) || []
 				workshopProps = {
 					...baseProps,
-					hasPurchasedCurrentProduct: Boolean(purchase),
+					hasPurchasedCurrentProduct:
+						purchase &&
+						(purchase.status === 'Valid' || purchase?.status === 'Restricted'),
 					existingPurchase,
 					quantityAvailable: product.quantityAvailable,
 					purchasedProductIds,

--- a/apps/value-based-design/src/lib/modules-query.ts
+++ b/apps/value-based-design/src/lib/modules-query.ts
@@ -35,20 +35,15 @@ export async function getModule(moduleSlugOrId: string) {
 		),
 		with: {
 			resources: {
+				// sections and stand-alone top level resource join
 				with: {
 					resource: {
+						// section or resource
 						with: {
 							resources: {
+								// lessons in section join
 								with: {
-									resource: {
-										with: {
-											resources: {
-												with: {
-													resource: true,
-												},
-											},
-										},
-									},
+									resource: true, //lesson, no need for more (videos etc)
 								},
 								orderBy: asc(contentResourceResource.position),
 							},
@@ -56,6 +51,15 @@ export async function getModule(moduleSlugOrId: string) {
 					},
 				},
 				orderBy: asc(contentResourceResource.position),
+			},
+			resourceProducts: {
+				with: {
+					product: {
+						with: {
+							price: true,
+						},
+					},
+				},
 			},
 		},
 	})

--- a/apps/value-based-design/src/trpc/api/routers/ability.ts
+++ b/apps/value-based-design/src/trpc/api/routers/ability.ts
@@ -4,7 +4,9 @@ import { env } from '@/env.mjs'
 import { SubscriberSchema } from '@/schemas/subscriber'
 import { getServerAuthSession } from '@/server/auth'
 import { createTRPCRouter, publicProcedure } from '@/trpc/api/trpc'
+import { getCurrentAbilityRules } from '@/utils/get-current-ability-rules'
 import { isEmpty } from 'lodash'
+import { z } from 'zod'
 
 const convertkitBaseUrl =
 	process.env.CONVERTKIT_BASE_URL || 'https://api.convertkit.com/v3/'
@@ -60,10 +62,19 @@ export async function getSubscriberFromCookie() {
 }
 
 export const abilityRouter = createTRPCRouter({
-	getCurrentAbilityRules: publicProcedure.query(async () => {
-		// const { session } = await getServerAuthSession()
-		// return getAbilityRules({ user: session?.user })
-
-		return getAbilityRules({})
-	}),
+	getCurrentAbilityRules: publicProcedure
+		.input(
+			z
+				.object({
+					lessonId: z.string().optional(),
+					moduleId: z.string().optional(),
+				})
+				.optional(),
+		)
+		.query(async ({ ctx, input }) => {
+			return getCurrentAbilityRules({
+				lessonId: input?.lessonId,
+				moduleId: input?.moduleId,
+			})
+		}),
 })

--- a/apps/value-based-design/src/utils/get-current-ability-rules.ts
+++ b/apps/value-based-design/src/utils/get-current-ability-rules.ts
@@ -1,11 +1,11 @@
 import { headers } from 'next/headers'
 import { createAppAbility, defineRulesForPurchases } from '@/ability'
+import { courseBuilderAdapter } from '@/db'
 import { getLesson } from '@/lib/lessons-query'
+import { Module } from '@/lib/module'
 import { getModule } from '@/lib/modules-query'
 import { getServerAuthSession } from '@/server/auth'
 import { getSubscriberFromCookie } from '@/trpc/api/routers/ability'
-
-import type { ContentResource } from '@coursebuilder/core/types'
 
 import { getResourceSection } from './get-resource-section'
 
@@ -34,17 +34,21 @@ export async function getCurrentAbilityRules({
 		module &&
 		(await getResourceSection(lessonResource.id, moduleResource))
 
+	const purchases = await courseBuilderAdapter.getPurchasesForUser(
+		session?.user?.id,
+	)
+
 	return defineRulesForPurchases({
 		user: session?.user,
+		country,
+		isSolution: false,
 		...(convertkitSubscriber && {
 			subscriber: convertkitSubscriber,
 		}),
-		country,
 		...(lessonResource && { lesson: lessonResource }),
 		...(moduleResource && { module: moduleResource }),
 		...(sectionResource ? { section: sectionResource } : {}),
-		isSolution: false,
-		purchasedModules: [],
+		...(purchases && { purchases: purchases }),
 	})
 }
 


### PR DESCRIPTION
This mimics the [work](https://github.com/badass-courses/course-builder/pull/215) @vojtaholik did in pro-nextjs.

Primarily implements `getCurrentAbilityRules` that return whether a user can view content they've purchased. Also updates the lesson list with lock icons for lessons that users don't have access too

## non-purchaser
![non-purchaser](https://github.com/user-attachments/assets/ee9433d9-313f-4046-9a99-9240e2737655)

![non-purchaser lesson](https://github.com/user-attachments/assets/de265896-3775-4f4d-8233-64898d27c4d3)


## purchaser 
![purchaser](https://github.com/user-attachments/assets/1a6d9b4f-fa9a-4ce3-bb52-c34655670964)

![purchaser lesson](https://github.com/user-attachments/assets/5e8a0ded-8056-412e-901d-129d7d20a275)


![gif](https://media4.giphy.com/media/ewT3jsroAqkgo2PLPi/giphy.gif?cid=1927fc1bp3k6vpttt2outcepb2qobutxpk3r5rgwovk4yih4&ep=v1_gifs_search&rid=giphy.gif&ct=g)