### PR TITLE
fix(jsv): fix colors and clean up

### DIFF
--- a/apps/js-visualized/src/app/page.tsx
+++ b/apps/js-visualized/src/app/page.tsx
@@ -12,7 +12,7 @@ export default async function PlaygroundPage() {
 	const cb = await coursebuilder()
 	return (
 		<div className="container pb-28">
-			<article className="prose sm:prose-xl dark:prose-invert prose-code:font-bold prose-code:font-sans max-w-none">
+			<article className="prose sm:prose-xl prose-code:font-bold prose-code:text-lg md:prose-code:text-xl prose-code:font-sans max-w-none">
 				<Landing />
 			</article>
 		</div>

--- a/apps/js-visualized/src/components/landing/introduce-author.tsx
+++ b/apps/js-visualized/src/components/landing/introduce-author.tsx
@@ -30,7 +30,7 @@ const IntroduceAuthor: React.FC<
 							className="lg:hidden"
 						/>
 					</div>
-					<div className="prose prose-lg dark:prose-invert prose-p:first-of-type:mt-0 prose-p:text-body-text prose-headings:font-bold prose-headings:mt-0 prose-headings:text-lg sm:prose-p:leading-[1.77] prose-p:leading-normal prose-p:mb-0 relative grow sm:text-balance">
+					<div className="prose prose-lg prose-p:first-of-type:mt-0 prose-p:text-body-text prose-headings:font-bold prose-headings:mt-0 prose-headings:text-lg sm:prose-p:leading-[1.77] prose-p:leading-normal prose-p:mb-0 relative grow sm:text-balance">
 						{children}
 					</div>
 				</SectionWrapper>

--- a/apps/js-visualized/src/components/landing/question-and-answer.tsx
+++ b/apps/js-visualized/src/components/landing/question-and-answer.tsx
@@ -22,7 +22,7 @@ const QuestionAndAnswer: React.FC<
 				<div className="prose-headings:my-0 prose-headings:font-normal prose-headings:text-[1.75rem] sm:prose-headings:text-3xl md:prose-headings:text-[2.5rem] prose-headings:leading-[1.4] sm:prose-headings:leading-[1.2]">
 					{title}
 				</div>
-				<div className="prose prose-lg md:prose-xl dark:prose-invert prose-p:first-of-type:mt-0 prose-p:last-of-type:mb-0">
+				<div className="prose prose-lg md:prose-xl prose-p:first-of-type:mt-0 prose-p:last-of-type:mb-0">
 					{content}
 				</div>
 			</SectionWrapper>

--- a/apps/js-visualized/src/components/navigation.tsx
+++ b/apps/js-visualized/src/components/navigation.tsx
@@ -30,11 +30,6 @@ const Navigation: React.FC<NavigationProps> = async ({
 
 export default Navigation
 
-type IconProps = {
-	isHovered: boolean
-	theme: 'light' | 'dark'
-}
-
 export const HamburgerMenuIcon = () => {
 	return (
 		<svg

--- a/apps/js-visualized/src/styles/globals.css
+++ b/apps/js-visualized/src/styles/globals.css
@@ -30,40 +30,6 @@
 		--jsv-charcoal-black: rgb(9, 9, 9);
 
 		/* shadcnui */
-		--background: 0 0% 100%;
-		--foreground: 222.2 84% 4.9%;
-
-		--card: 0 0% 100%;
-		--card-foreground: 222.2 84% 4.9%;
-
-		--popover: 0 0% 100%;
-		--popover-foreground: 222.2 84% 4.9%;
-
-		--primary: 222.2 47.4% 11.2%;
-		--primary-foreground: 210 40% 98%;
-
-		--secondary: 210 40% 96.1%;
-		--secondary-foreground: 222.2 47.4% 11.2%;
-
-		--muted: 210 40% 96.1%;
-		--muted-foreground: 215.4 16.3% 46.9%;
-
-		--accent: 210 40% 96.1%;
-		--accent-foreground: 222.2 47.4% 11.2%;
-
-		--destructive: 0 84.2% 60.2%;
-		--destructive-foreground: 210 40% 98%;
-
-		--border: 214.3 31.8% 91.4%;
-		--input: 214.3 31.8% 91.4%;
-		--ring: 222.2 84% 4.9%;
-
-		--radius: 0.5rem;
-
-		--grid: 8px;
-	}
-
-	.dark {
 		--background: 222.2 84% 4.9%;
 		--foreground: 210 40% 98%;
 
@@ -91,6 +57,10 @@
 		--border: 217.2 32.6% 17.5%;
 		--input: 217.2 32.6% 17.5%;
 		--ring: 212.7 26.8% 83.9%;
+
+		--radius: 0.5rem;
+
+		--grid: 8px;
 	}
 }
 

--- a/apps/js-visualized/tailwind.config.ts
+++ b/apps/js-visualized/tailwind.config.ts
@@ -115,13 +115,16 @@ const config: Config = {
 					'linear-gradient(to right, #292B2C,#000,#292B2C,#292B2C,#000,#292B2C)',
 			},
 			typography: ({ theme }: { theme: any }) => ({
-				invert: {
+				DEFAULT: {
 					css: {
 						'--tw-prose-headings': 'var(--jsv-misty-white)',
 						'--tw-prose-body': 'var(--jsv-ghostly-white)',
 						lineHeight: '1.6',
 						strong: {
 							fontWeight: '700',
+							color: 'white',
+						},
+						code: {
 							color: 'white',
 						},
 					},


### PR DESCRIPTION
I noticed that when Light Appearance is enabled on iPhone, some colors are distorted:

<details>
  <summary>Before:</summary>
  <img width="390" src="https://github.com/user-attachments/assets/21eaba1b-84af-4ea4-8822-0b83a79ca0ba">
</details>
<details>
  <summary>After:</summary>
  <img width="390" src="https://github.com/user-attachments/assets/99cde0ed-592e-4f10-a8e0-b2f165a876ea">
</details>


![Glitch Colors GIF by XCOPY](https://github.com/user-attachments/assets/24004fed-5adc-4c6e-b620-29394bbc94be)

