### PR TITLE
feat(pnjs): configurable AutoComplete & AutoPlay

### DIFF
--- a/apps/pro-nextjs/src/app/(content)/_components/autoplay-toggle.tsx
+++ b/apps/pro-nextjs/src/app/(content)/_components/autoplay-toggle.tsx
@@ -1,12 +1,15 @@
 'use client'
 
 import * as React from 'react'
+import { useWorkshopNavigation } from '@/app/(content)/workshops/_components/workshop-navigation-provider'
 import { useMuxPlayerPrefs } from '@/hooks/use-mux-player-prefs'
 
 import { Label, Switch } from '@coursebuilder/ui'
 import { cn } from '@coursebuilder/ui/utils/cn'
 
 export function AutoPlayToggle({ className }: { className?: string }) {
+	const workshopNavigation = useWorkshopNavigation()
+	const isAutoPlayAvailable = workshopNavigation?.autoPlay === 'available'
 	const { getPlayerPrefs, setPlayerPrefs } = useMuxPlayerPrefs()
 	const playerPrefs = getPlayerPrefs()
 	const bingeMode = playerPrefs.autoplay
@@ -15,7 +18,7 @@ export function AutoPlayToggle({ className }: { className?: string }) {
 		setMounted(true)
 	}, [])
 
-	return mounted ? (
+	return mounted && isAutoPlayAvailable ? (
 		<div className={cn('flex items-center gap-2', className)}>
 			<Label htmlFor="binge-mode-toggle">Autoplay</Label>
 			<Switch

--- a/apps/pro-nextjs/src/app/(content)/_components/video-player-overlay.tsx
+++ b/apps/pro-nextjs/src/app/(content)/_components/video-player-overlay.tsx
@@ -28,6 +28,7 @@ import type { CompletedAction } from '@coursebuilder/ui/hooks/use-video-player-o
 
 import { VideoOverlayWorkshopPricing } from '../workshops/_components/video-overlay-pricing-widget'
 import type { WorkshopPageProps } from '../workshops/_components/workshop-page-props'
+import { useModuleProgress } from './module-progress-provider'
 
 export const CompletedLessonOverlay: React.FC<{
 	action: CompletedAction
@@ -41,10 +42,7 @@ export const CompletedLessonOverlay: React.FC<{
 	const moduleNavigation = useWorkshopNavigation()
 	const { dispatch: dispatchVideoPlayerOverlay } = useVideoPlayerOverlay()
 
-	const { data: moduleProgress } =
-		api.progress.getModuleProgressForUser.useQuery({
-			moduleId: moduleNavigation?.id,
-		})
+	const moduleProgress = useModuleProgress()
 
 	const [completedLessonsCount, setCompletedLessonsCount] = React.useState(
 		moduleProgress?.completedLessonsCount || 0,

--- a/apps/pro-nextjs/src/app/(content)/workshops/_components/edit-workshop-form.tsx
+++ b/apps/pro-nextjs/src/app/(content)/workshops/_components/edit-workshop-form.tsx
@@ -6,7 +6,7 @@ import WorkshopResourcesList from '@/components/workshop-resources-edit'
 import { env } from '@/env.mjs'
 import { useIsMobile } from '@/hooks/use-is-mobile'
 import { sendResourceChatMessage } from '@/lib/ai-chat-query'
-import { ModuleSchema } from '@/lib/module'
+import { ModuleSchema, type Module } from '@/lib/module'
 import { updateWorkshop } from '@/lib/workshops-query'
 import { getOGImageUrlForResource } from '@/utils/get-og-image-url-for-resource'
 import { zodResolver } from '@hookform/resolvers/zod'
@@ -19,12 +19,19 @@ import { z } from 'zod'
 import { ContentResourceSchema } from '@coursebuilder/core/schemas/content-resource-schema'
 import type { ContentResource } from '@coursebuilder/core/types'
 import {
+	FormControl,
 	FormDescription,
 	FormField,
 	FormItem,
 	FormLabel,
 	FormMessage,
 	Input,
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+	Switch,
 	Textarea,
 } from '@coursebuilder/ui'
 import { EditResourcesFormDesktop } from '@coursebuilder/ui/resources-crud/edit-resources-form-desktop'
@@ -35,7 +42,7 @@ import { MetadataFieldVisibility } from '@coursebuilder/ui/resources-crud/metada
 
 import { onWorkshopSave } from '../[module]/edit/actions'
 
-export function EditWorkshopForm({ workshop }: { workshop: ContentResource }) {
+export function EditWorkshopForm({ workshop }: { workshop: Module }) {
 	const form = useForm<z.infer<typeof ModuleSchema>>({
 		resolver: zodResolver(ModuleSchema),
 		defaultValues: {
@@ -49,6 +56,8 @@ export function EditWorkshopForm({ workshop }: { workshop: ContentResource }) {
 				visibility: workshop.fields?.visibility || 'unlisted',
 				coverImage: workshop?.fields?.coverImage || { url: '', alt: '' },
 				github: workshop?.fields?.github || '',
+				autoPlay: workshop?.fields?.autoPlay || 'available',
+				autoComplete: workshop?.fields?.autoComplete || false,
 			},
 		},
 	})
@@ -219,6 +228,46 @@ export function EditWorkshopForm({ workshop }: { workshop: ContentResource }) {
 						form.getValues() as unknown as ContentResource & {
 							fields?: { slug: string }
 						},
+					)}
+				/>
+				<FormField
+					name="fields.autoPlay"
+					control={form.control}
+					render={({ field }) => (
+						<FormItem className="px-5">
+							<FormLabel className="text-lg font-bold">Autoplay</FormLabel>
+							<Select onValueChange={field.onChange} defaultValue={field.value}>
+								<FormControl>
+									<SelectTrigger className="w-full">
+										<SelectValue placeholder="Select..." />
+									</SelectTrigger>
+								</FormControl>
+								<SelectContent>
+									<SelectItem value="available">
+										Available (user controlled)
+									</SelectItem>
+									<SelectItem value="on">On</SelectItem>
+									<SelectItem value="off">Off</SelectItem>
+								</SelectContent>
+							</Select>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+				<FormField
+					name="fields.autoComplete"
+					control={form.control}
+					render={({ field }) => (
+						<FormItem className="flex w-full items-center justify-between px-5">
+							<FormLabel className="text-lg font-bold">Auto Complete</FormLabel>
+							<FormControl>
+								<Switch
+									checked={field.value}
+									onCheckedChange={field.onChange}
+								/>
+							</FormControl>
+							<FormMessage />
+						</FormItem>
 					)}
 				/>
 				{/* <WorkshopResourcesList workshop={workshop} /> */}

--- a/apps/pro-nextjs/src/app/(content)/workshops/_components/edit-workshop-form.tsx
+++ b/apps/pro-nextjs/src/app/(content)/workshops/_components/edit-workshop-form.tsx
@@ -42,7 +42,7 @@ import { MetadataFieldVisibility } from '@coursebuilder/ui/resources-crud/metada
 
 import { onWorkshopSave } from '../[module]/edit/actions'
 
-export function EditWorkshopForm({ workshop }: { workshop: Module }) {
+export function EditWorkshopForm({ workshop }: { workshop: ContentResource }) {
 	const form = useForm<z.infer<typeof ModuleSchema>>({
 		resolver: zodResolver(ModuleSchema),
 		defaultValues: {

--- a/apps/pro-nextjs/src/components/lesson-list/pieces/tree/tree-context.tsx
+++ b/apps/pro-nextjs/src/components/lesson-list/pieces/tree/tree-context.tsx
@@ -1,4 +1,5 @@
 import React, { createContext } from 'react'
+import type { Module } from '@/lib/module'
 import {
 	attachInstruction,
 	extractInstruction,
@@ -16,7 +17,7 @@ export type TreeContextValue = {
 	getMoveTargets: ({ itemId }: { itemId: string }) => TreeItem[]
 	getChildrenOfItem: (itemId: string) => TreeItem[]
 	rootResourceId: string | null
-	rootResource: ContentResource | Product | null
+	rootResource: ContentResource | Product | Module | null
 	registerTreeItem: (args: {
 		itemId: string
 		element: HTMLElement

--- a/apps/pro-nextjs/src/components/lesson-list/tree.tsx
+++ b/apps/pro-nextjs/src/components/lesson-list/tree.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react'
 import { useParams, useRouter, useSearchParams } from 'next/navigation'
 import { courseBuilderConfig } from '@/coursebuilder/course-builder-config'
+import type { Module } from '@/lib/module'
 import {
 	updateResourcePosition,
 	updateResourcePositions,
@@ -77,7 +78,7 @@ export default function Tree({
 	state: TreeState
 	updateState: React.Dispatch<TreeAction>
 	rootResourceId: string
-	rootResource: ContentResource | Product
+	rootResource: ContentResource | Module | Product
 }) {
 	const params = useParams<{ module: string }>()
 

--- a/apps/pro-nextjs/src/components/workshop-resources-edit.tsx
+++ b/apps/pro-nextjs/src/components/workshop-resources-edit.tsx
@@ -19,7 +19,7 @@ import { CreateResourceForm } from '@coursebuilder/ui/resources-crud/create-reso
 export default function WorkshopResourcesEdit({
 	workshop,
 }: {
-	workshop: Module
+	workshop: ContentResource
 }) {
 	const [isAddingLesson, setIsAddingLesson] = React.useState(false)
 	const [isAddingSection, setIsAddingSection] = React.useState(false)

--- a/apps/pro-nextjs/src/components/workshop-resources-edit.tsx
+++ b/apps/pro-nextjs/src/components/workshop-resources-edit.tsx
@@ -8,6 +8,7 @@ import {
 	treeStateReducer,
 } from '@/components/lesson-list/data/tree'
 import Tree from '@/components/lesson-list/tree'
+import type { Module } from '@/lib/module'
 import { createResource } from '@/lib/resources/create-resources'
 import { addResourceToWorkshop } from '@/lib/workshops-query'
 
@@ -18,7 +19,7 @@ import { CreateResourceForm } from '@coursebuilder/ui/resources-crud/create-reso
 export default function WorkshopResourcesEdit({
 	workshop,
 }: {
-	workshop: ContentResource
+	workshop: Module
 }) {
 	const [isAddingLesson, setIsAddingLesson] = React.useState(false)
 	const [isAddingSection, setIsAddingSection] = React.useState(false)
@@ -87,7 +88,7 @@ export default function WorkshopResourcesEdit({
 		<>
 			<span className="px-5 text-lg font-bold">Resources</span>
 			<Tree
-				rootResource={workshop as ContentResource}
+				rootResource={workshop}
 				rootResourceId={workshop.id}
 				state={state}
 				updateState={updateState}

--- a/apps/pro-nextjs/src/lib/module.ts
+++ b/apps/pro-nextjs/src/lib/module.ts
@@ -21,6 +21,8 @@ export const ModuleSchema = z.object({
 		body: z.string().optional().nullable(),
 		description: z.string().optional().nullable(),
 		github: z.string().optional().nullable(),
+		autoPlay: z.enum(['available', 'on', 'off']).default('available'),
+		autoComplete: z.boolean().default(false),
 		state: z
 			.enum(['draft', 'published', 'archived', 'deleted'])
 			.default('draft'),

--- a/apps/pro-nextjs/src/lib/workshops-query.ts
+++ b/apps/pro-nextjs/src/lib/workshops-query.ts
@@ -34,6 +34,8 @@ async function getAllWorkshopLessonsWithSectionInfo(
     workshop.fields->>'$.slug' AS workshop_slug,
     workshop.fields->>'$.title' AS workshop_title,
     workshop.fields->>'$.coverImage.url' AS workshop_image,
+		workshop.fields->>'$.autoPlay' AS workshop_autoPlay,
+		workshop.fields->>'$.autoComplete' AS workshop_autoComplete,
     CASE
         WHEN combined.item_type = 'section' THEN combined.section_id
         ELSE NULL
@@ -206,6 +208,8 @@ export async function getWorkshopNavigation(
 		slug: workshop.workshop_slug,
 		title: workshop.workshop_title,
 		coverImage: workshop.workshop_image,
+		autoPlay: workshop.workshop_autoPlay,
+		autoComplete: Boolean(workshop.workshop_autoComplete === 'true'),
 		resources,
 	})
 }

--- a/apps/pro-nextjs/src/lib/workshops.ts
+++ b/apps/pro-nextjs/src/lib/workshops.ts
@@ -5,6 +5,8 @@ export const NavigationResultSchema = z.object({
 	workshop_slug: z.string(),
 	workshop_title: z.string(),
 	workshop_image: z.string().optional().nullable(),
+	workshop_autoPlay: z.enum(['available', 'on', 'off']).default('available'),
+	workshop_autoComplete: z.string().default('false'),
 	section_id: z.string().nullable(),
 	section_slug: z.string().nullable(),
 	section_title: z.string().nullable(),
@@ -46,6 +48,8 @@ export const WorkshopNavigationSchema = z.object({
 	title: z.string(),
 	coverImage: z.string().optional().nullable(),
 	resources: z.array(NavigationResourceSchema),
+	autoPlay: z.enum(['available', 'on', 'off']).default('available'),
+	autoComplete: z.boolean().default(false),
 })
 
 export function findSectionIdForLessonSlug(


### PR DESCRIPTION
this allows for controlling AutoComplete and AutoPlay individually on module level.

AutoPlay can either be `available` (user controlled, displays a toggle), `on`, or `off`. Its function is to skip overlay and navigate to next resource right away. AutoComplete is either `true` or `false` and is used to mark resource progress when video finishes playing. this combination allows for displaying overlay while toggling progress automatically, etc.

although it does work, I'm leaving it as draft because I'm still unsure about it from both feature and technical solution perspective.

<img width="378" alt="image" src="https://github.com/user-attachments/assets/93d0715c-c401-4a14-a3f8-58c04ad42eff">

<img src="https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExa3htcngyaWIzMTF2bW9jaTNsdmE1cTltaDBmMmc3NzA4NWg5YXdhcCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/EjYZ6BtDeXmUM/giphy-downsized.gif" width="200" alt="gif">