### PR TITLE
feat(egh): enforce consistent guid on post creation

### DIFF
--- a/apps/egghead/src/lib/posts-query.ts
+++ b/apps/egghead/src/lib/posts-query.ts
@@ -132,7 +132,8 @@ export async function createPost(input: NewPost) {
 		},
 	}).then(async (res) => await res.json())
 
-	const newPostId = `post_${guid()}`
+	const postGuid = guid()
+	const newPostId = `post_${postGuid}`
 
 	const videoResource = await courseBuilderAdapter.getVideoResource(
 		input.videoResourceId,
@@ -149,7 +150,7 @@ export async function createPost(input: NewPost) {
 		[
 			input.title,
 			profile.instructor.id,
-			slugify(`${input.title}~${guid()}`),
+			slugify(`${input.title}~${postGuid}`),
 			'post',
 		],
 	)
@@ -166,7 +167,7 @@ export async function createPost(input: NewPost) {
 				title: input.title,
 				state: 'draft',
 				visibility: 'unlisted',
-				slug: slugify(`${input.title}~${guid()}`),
+				slug: slugify(`${input.title}~${postGuid}`),
 				eggheadLessonId,
 			},
 		})


### PR DESCRIPTION
Uses the same guid for a posts `id`, `slug`, and slug in rails lesson object


![gif](https://media3.giphy.com/media/SElw9wE2GSvHXx9aiu/giphy.gif?cid=1927fc1bgy1e1toib6s1rww4dhqnqyjgrcirv5bl8ym9qvij&ep=v1_gifs_search&rid=giphy.gif&ct=g)