### PR TITLE
feat(egh): allow creating non-video posts

### DIFF
--- a/apps/egghead/src/app/(content)/[post]/page.tsx
+++ b/apps/egghead/src/app/(content)/[post]/page.tsx
@@ -120,9 +120,9 @@ async function PlayerContainer({
 
 	const resource = post.resources?.[0]?.resource.id
 
-	const videoResourceLoader = courseBuilderAdapter.getVideoResource(resource)
+	const videoResource = await courseBuilderAdapter.getVideoResource(resource)
 
-	return (
+	return videoResource ? (
 		<Suspense fallback={<PlayerContainerSkeleton />}>
 			<div className="relative z-10 flex items-center justify-center">
 				<div className="flex w-full max-w-screen-lg flex-col">
@@ -135,13 +135,13 @@ async function PlayerContainer({
 								},
 							)}
 						>
-							<PostPlayer videoResourceLoader={videoResourceLoader} />
+							<PostPlayer videoResource={videoResource} />
 						</div>
 					</div>
 				</div>
 			</div>
 		</Suspense>
-	)
+	) : null
 }
 
 async function PostBody({ postLoader }: { postLoader: Promise<Post | null> }) {
@@ -160,10 +160,10 @@ async function PostBody({ postLoader }: { postLoader: Promise<Post | null> }) {
 				{post.fields.title}
 			</h1>
 
-			<div className="align-right flex w-full justify-end gap-2">
+			<div className="flex w-full justify-start gap-2">
 				<Link
 					href={`https://egghead.io/${post.fields.slug}`}
-					className="underline underline-offset-2 hover:underline"
+					className="text-muted-foreground mb-5 text-sm underline underline-offset-2 hover:underline"
 					target="_blank"
 				>
 					Open on egghead

--- a/apps/egghead/src/app/(content)/[post]/transcript.tsx
+++ b/apps/egghead/src/app/(content)/[post]/transcript.tsx
@@ -10,12 +10,12 @@ export function TranscriptContainer({
 	transcriptLoader: Promise<string | null | undefined>
 }) {
 	const transcript = use(transcriptLoader)
-	return (
+	return transcript ? (
 		<div className="w-full max-w-2xl pt-5">
 			<h3 className="font-bold">Transcript</h3>
 			<ReactMarkdown className="prose dark:prose-invert">
 				{transcript}
 			</ReactMarkdown>
 		</div>
-	)
+	) : null
 }

--- a/apps/egghead/src/app/(content)/posts/_components/edit-post-form-metadata.tsx
+++ b/apps/egghead/src/app/(content)/posts/_components/edit-post-form-metadata.tsx
@@ -20,12 +20,17 @@ import {
 	FormLabel,
 	FormMessage,
 	Input,
+	Textarea,
 	Tooltip,
 	TooltipContent,
 	TooltipProvider,
 	TooltipTrigger,
 } from '@coursebuilder/ui'
 import { useSocket } from '@coursebuilder/ui/hooks/use-socket'
+import { MetadataFieldState } from '@coursebuilder/ui/resources-crud/metadata-fields/metadata-field-state'
+import { MetadataFieldVisibility } from '@coursebuilder/ui/resources-crud/metadata-fields/metadata-field-visibility'
+
+import { PostUploader } from './post-uploader'
 
 export const PostMetadataFormFields: React.FC<{
 	form: UseFormReturn<z.infer<typeof PostSchema>>
@@ -74,19 +79,33 @@ export const PostMetadataFormFields: React.FC<{
 	return (
 		<>
 			<div>
-				<Suspense
-					fallback={
-						<>
-							<div className="bg-muted flex aspect-video h-full w-full items-center justify-center p-5">
-								video is loading
-							</div>
-						</>
-					}
-				>
-					<PostPlayer videoResourceLoader={videoResourceLoader} />
+				{videoResourceId && videoResource ? (
+					<Suspense
+						fallback={
+							<>
+								<div className="bg-muted flex aspect-video h-full w-full items-center justify-center p-5">
+									video is loading
+								</div>
+							</>
+						}
+					>
+						<PostPlayer videoResource={videoResource} />
 
-					<div className="px-5 text-xs">video is {videoResource?.state}</div>
-				</Suspense>
+						<div className="text-muted-foreground px-5 text-xs">
+							video is {videoResource?.state}
+						</div>
+					</Suspense>
+				) : (
+					<div>
+						<PostUploader
+							setVideoResourceId={setVideoResourceId}
+							parentResourceId={post.id}
+						/>
+						<div className="text-muted-foreground px-5 text-xs">
+							Upload a video if you'd like.
+						</div>
+					</div>
+				)}
 			</div>
 			<FormField
 				control={form.control}
@@ -108,35 +127,91 @@ export const PostMetadataFormFields: React.FC<{
 					</FormItem>
 				)}
 			/>
-			<div className="px-5">
-				<div className="flex items-center justify-between gap-2">
-					<label className="text-lg font-bold">Transcript</label>
-					{Boolean(videoResourceId) && (
-						<TooltipProvider delayDuration={0}>
-							<Tooltip>
-								<TooltipTrigger asChild>
-									<Button
-										variant="ghost"
-										size="icon"
-										type="button"
-										onClick={async (event) => {
-											event.preventDefault()
-											await reprocessTranscript({ videoResourceId })
-										}}
-										title="Reprocess"
-									>
-										<RefreshCcw className="w-3" />
-									</Button>
-								</TooltipTrigger>
-								<TooltipContent side="top">Reprocess Transcript</TooltipContent>
-							</Tooltip>
-						</TooltipProvider>
-					)}
+			<FormField
+				control={form.control}
+				name="fields.description"
+				render={({ field }) => (
+					<FormItem className="px-5">
+						<FormLabel className="text-lg font-bold">
+							SEO Description ({`${field.value?.length ?? '0'} / 160`})
+						</FormLabel>
+						<FormDescription>
+							A short snippet that summarizes the post in under 160 characters.
+							Keywords should be included to support SEO.
+						</FormDescription>
+						<Textarea {...field} value={field.value ?? ''} />
+						{field.value && field.value.length > 160 && (
+							<FormMessage>
+								Your description is longer than 160 characters
+							</FormMessage>
+						)}
+						<FormMessage />
+					</FormItem>
+				)}
+			/>
+			<MetadataFieldVisibility form={form} />
+			<MetadataFieldState form={form} />
+			<FormField
+				control={form.control}
+				name="fields.github"
+				render={({ field }) => (
+					<FormItem className="px-5">
+						<FormLabel className="text-lg font-bold">GitHub</FormLabel>
+						<FormDescription>
+							Direct link to the GitHub file associated with the post.
+						</FormDescription>
+						<Input {...field} value={field.value ?? ''} />
+						<FormMessage />
+					</FormItem>
+				)}
+			/>
+			<FormField
+				control={form.control}
+				name="fields.gitpod"
+				render={({ field }) => (
+					<FormItem className="px-5">
+						<FormLabel className="text-lg font-bold">Gitpod</FormLabel>
+						<FormDescription>
+							Gitpod link to start a new workspace with the post.
+						</FormDescription>
+						<Input {...field} value={field.value ?? ''} />
+						<FormMessage />
+					</FormItem>
+				)}
+			/>
+			{videoResource && (
+				<div className="px-5">
+					<div className="flex items-center justify-between gap-2">
+						<label className="text-lg font-bold">Transcript</label>
+						{Boolean(videoResourceId) && (
+							<TooltipProvider delayDuration={0}>
+								<Tooltip>
+									<TooltipTrigger asChild>
+										<Button
+											variant="ghost"
+											size="icon"
+											type="button"
+											onClick={async (event) => {
+												event.preventDefault()
+												await reprocessTranscript({ videoResourceId })
+											}}
+											title="Reprocess"
+										>
+											<RefreshCcw className="w-3" />
+										</Button>
+									</TooltipTrigger>
+									<TooltipContent side="top">
+										Reprocess Transcript
+									</TooltipContent>
+								</Tooltip>
+							</TooltipProvider>
+						)}
+					</div>
+					<ReactMarkdown className="prose prose-sm dark:prose-invert before:from-background relative mt-3 h-48 max-w-none overflow-hidden before:absolute before:bottom-0 before:left-0 before:z-10 before:h-24 before:w-full before:bg-gradient-to-t before:to-transparent before:content-[''] md:h-auto md:before:h-0">
+						{transcript ? transcript : 'Transcript Processing'}
+					</ReactMarkdown>
 				</div>
-				<ReactMarkdown className="prose prose-sm dark:prose-invert before:from-background relative mt-3 h-48 max-w-none overflow-hidden before:absolute before:bottom-0 before:left-0 before:z-10 before:h-24 before:w-full before:bg-gradient-to-t before:to-transparent before:content-[''] md:h-auto md:before:h-0">
-					{transcript ? transcript : 'Transcript Processing'}
-				</ReactMarkdown>
-			</div>
+			)}
 		</>
 	)
 }

--- a/apps/egghead/src/app/(content)/posts/_components/edit-post-form.tsx
+++ b/apps/egghead/src/app/(content)/posts/_components/edit-post-form.tsx
@@ -20,7 +20,11 @@ import { EditResourcesFormDesktop } from '@coursebuilder/ui/resources-crud/edit-
 
 const NewPostFormSchema = z.object({
 	title: z.string().min(2).max(90),
-	body: z.string().optional().nullable(),
+	body: z.string().nullish(),
+	visibility: z.enum(['public', 'unlisted', 'private']),
+	description: z.string().nullish(),
+	github: z.string().nullish(),
+	gitpod: z.string().nullish(),
 })
 
 export type EditPostFormProps = {
@@ -45,6 +49,11 @@ export function EditPostForm({
 			fields: {
 				title: post.fields?.title,
 				body: post.fields?.body,
+				visibility: post.fields?.visibility || 'unlisted',
+				state: post.fields?.state || 'draft',
+				description: post.fields?.description ?? '',
+				github: post.fields?.github ?? '',
+				gitpod: post.fields?.gitpod ?? '',
 			},
 		},
 	})

--- a/apps/egghead/src/app/(content)/posts/_components/post-player.tsx
+++ b/apps/egghead/src/app/(content)/posts/_components/post-player.tsx
@@ -12,10 +12,10 @@ import { cn } from '@coursebuilder/ui/utils/cn'
 export function PostPlayer({
 	muxPlaybackId,
 	className,
-	videoResourceLoader,
+	videoResource,
 }: {
 	muxPlaybackId?: string
-	videoResourceLoader: Promise<VideoResource | null>
+	videoResource: VideoResource
 	className?: string
 }) {
 	const playerProps = {
@@ -27,8 +27,6 @@ export function PostPlayer({
 		maxResolution: '2160p',
 		minResolution: '540p',
 	} as MuxPlayerProps
-
-	const videoResource = use(videoResourceLoader)
 
 	const playbackId =
 		videoResource?.state === 'ready'

--- a/apps/egghead/src/lib/posts.ts
+++ b/apps/egghead/src/lib/posts.ts
@@ -25,6 +25,9 @@ export const PostSchema = ContentResourceSchema.merge(
 			visibility: PostVisibilitySchema.default('unlisted'),
 			eggheadLessonId: z.coerce.number().nullish(),
 			slug: z.string(),
+			description: z.string().nullish(),
+			github: z.string().nullish(),
+			gitpod: z.string().nullish(),
 		}),
 	}),
 )
@@ -33,7 +36,7 @@ export type Post = z.infer<typeof PostSchema>
 
 export const NewPostSchema = z.object({
 	title: z.string().min(2).max(90),
-	videoResourceId: z.string().min(4, 'Please upload a video'),
+	videoResourceId: z.string().min(4, 'Please upload a video').nullish(),
 })
 
 export type NewPost = z.infer<typeof NewPostSchema>

--- a/packages/ui/resources-crud/new-resource-with-video-form.tsx
+++ b/packages/ui/resources-crud/new-resource-with-video-form.tsx
@@ -213,9 +213,12 @@ export function NewResourceWithVideoForm({
 					render={({ field }) => (
 						<FormItem>
 							<FormLabel>
-								{videoResourceId ? 'Video' : 'Upload a Video*'}
+								{videoResourceId ? 'Video' : 'Upload a Video'}
 							</FormLabel>
 							<FormDescription>
+								<span className="block">
+									You can upload a video later if needed.
+								</span>
 								Your video will be uploaded and then transcribed automatically.
 							</FormDescription>
 							<FormControl>


### PR DESCRIPTION
This allows instructors to create posts without a `videoResource` attached to the post. On the edit screen instructors can add a video if they end up wanting one on the post.

I also added other metadata to post edit form like visibility, state, SEO description, and github. We don't use them on the egghead side yet but having that data won't hurt.

![post](https://github.com/user-attachments/assets/d64f6ac3-e2b6-4571-b8dc-1f4af8a64d20)
![post edit](https://github.com/user-attachments/assets/5f4f5f25-01b4-428b-9df9-45e95840f5ee)

![gif](https://media4.giphy.com/media/da75JuW2HHuBNqOHHE/giphy.gif?cid=1927fc1btpp4tnnjw3slusjry77943qv9xfe8pc0qdrrkvo3&ep=v1_gifs_search&rid=giphy.gif&ct=g)
