### PR TITLE
Zac/add footer link to privacy page

### DIFF
--- a/apps/astro-party/src/app/page.tsx
+++ b/apps/astro-party/src/app/page.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { type Metadata } from 'next'
 import Image from 'next/image'
+import Footer from '@/components/app/footer'
 import { Layout } from '@/components/layout'
 import { PrimaryNewsletterCta } from '@/components/primary-newsletter-cta'
 import config from '@/config'
@@ -100,6 +101,7 @@ export default async function Home() {
 					</h2>
 				</PrimaryNewsletterCta>
 			</main>
+			<Footer />
 		</Layout>
 	)
 }

--- a/apps/astro-party/src/app/privacy/page.tsx
+++ b/apps/astro-party/src/app/privacy/page.tsx
@@ -2,8 +2,27 @@ import ReactMarkdown from 'react-markdown'
 
 const PrivacyPage = () => (
 	<main className="p-5 py-16 lg:py-24">
-		<article className="prose dark:prose-invert mx-auto">
-			<ReactMarkdown>{markdownContent}</ReactMarkdown>
+		<article className="prose dark:prose-invert mx-auto text-white">
+			<ReactMarkdown
+				components={{
+					h1: ({ children }) => (
+						<h1 className="text-4xl text-white">{children}</h1>
+					),
+					h2: ({ children }) => (
+						<h2 className="text-xl text-white">{children}</h2>
+					),
+					h3: ({ children }) => (
+						<h3 className="text-lg text-white">{children}</h3>
+					),
+					a: ({ children, href }) => (
+						<a href={href} className="text-white underline">
+							{children}
+						</a>
+					),
+				}}
+			>
+				{markdownContent}
+			</ReactMarkdown>
 		</article>
 	</main>
 )

--- a/apps/astro-party/src/components/app/footer.tsx
+++ b/apps/astro-party/src/components/app/footer.tsx
@@ -1,0 +1,17 @@
+import Link from 'next/link'
+
+export default function Footer() {
+	return (
+		<footer className="relative mx-auto flex w-full max-w-screen-lg flex-col items-start justify-between gap-16 px-5 pb-48 pt-14 sm:flex-row sm:px-10 sm:pt-16 lg:px-5">
+			<small className="absolute bottom-5 left-5 flex items-center gap-5 text-white">
+				<span className="opacity-75">© astro.party</span>
+				<Link
+					className="opacity-75 transition hover:opacity-100"
+					href="/privacy"
+				>
+					Terms & Conditions
+				</Link>
+			</small>
+		</footer>
+	)
+}

--- a/apps/js-visualized/src/app/privacy/page.tsx
+++ b/apps/js-visualized/src/app/privacy/page.tsx
@@ -1,0 +1,252 @@
+import ReactMarkdown from 'react-markdown'
+
+const PrivacyPage = () => (
+	<main className="p-5 py-16 lg:py-24">
+		<article className="prose dark:prose-invert mx-auto">
+			<ReactMarkdown>{markdownContent}</ReactMarkdown>
+		</article>
+	</main>
+)
+
+export default PrivacyPage
+
+const markdownContent = `
+# Terms, Conditions, and Privacy Policy
+
+## Overview
+
+This website is operated by Skill Recordings Inc. Throughout the site, the terms “we”, “us” and “our” refer to Skill Recordings Inc. Skill Recordings Inc. offers this website, including all information, tools and services available from this site to you, the user, conditioned upon your acceptance of all terms, conditions, policies and notices stated here.
+
+By visiting our site and/or purchasing something from us, you engage in our “Service” and agree to be bound by the following terms and conditions (“Terms of Service”, “Terms”), including those additional terms and conditions and policies referenced herein and/or available by hyperlink. These Terms of Service apply to all users of the site, including without limitation users who are browsers, vendors, customers, merchants, and/or contributors of content.
+
+Please read these Terms of Service carefully before accessing or using our website. By accessing or using any part of the site, you agree to be bound by these Terms of Service. If you do not agree to all the terms and conditions of this agreement, then you may not access the website or use any services. If these Terms of Service are considered an offer, acceptance is expressly limited to these Terms of Service.
+
+Any new features or tools which are added to the current store shall also be subject to the Terms of Service. You can review the most current version of the Terms of Service at any time on this page. We reserve the right to update, change or replace any part of these Terms of Service by posting updates and/or changes to our website. It is your responsibility to check this page periodically for changes. Your continued use of or access to the website following the posting of any changes constitutes acceptance of those changes.
+
+Our storefront is created with Gatsby. They provide us with the online e-commerce platform that allows us to sell our products and services to you.
+
+## Section 1: Online Store Terms
+
+By agreeing to these Terms of Service, you represent that you are at least the age of majority in your state or province of residence, or that you are the age of majority in your state or province of residence and you have given us your consent to allow any of your minor dependents to use this site.
+
+You may not use our products for any illegal or unauthorized purpose nor may you, in the use of the Service, violate any laws in your jurisdiction (including but not limited to copyright laws).
+
+You must not transmit any worms or viruses or any code of a destructive nature.
+
+A breach or violation of any of the Terms will result in an immediate termination of your Services.
+
+## Section 2: General Conditions
+
+We reserve the right to refuse service to anyone for any reason at any time.
+You understand that your content (not including credit card information), may be transferred unencrypted and involve (a) transmissions over various networks; and (b) changes to conform and adapt to technical requirements of connecting networks or devices. Credit card information is always encrypted during transfer over networks.
+
+You agree not to reproduce, duplicate, copy, sell, resell or exploit any portion of the Service, use of the Service, or access to the Service or any contact on the website through which the service is provided, without express written permission by us.
+
+The headings used in this agreement are included for convenience only and will not limit or otherwise affect these Terms.
+
+Section 3: Accuracy, Completeness and Timeliness of Information
+We are not responsible if information made available on this site is not accurate, complete or current. The material on this site is provided for general information only and should not be relied upon or used as the sole basis for making decisions without consulting primary, more accurate, more complete or more timely sources of information. Any reliance on the material on this site is at your own risk.
+
+This site may contain certain historical information. Historical information, necessarily, is not current and is provided for your reference only. We reserve the right to modify the contents of this site at any time, but we have no obligation to update any information on our site. You agree that it is your responsibility to monitor changes to our site.
+
+## Section 4: Modifications to the Service and Prices
+
+Prices for our products are subject to change without notice.
+We reserve the right at any time to modify or discontinue the Service (or any part or content thereof) without notice at any time.
+
+We shall not be liable to you or to any third-party for any modification, price change, suspension or discontinuance of the Service.
+
+## Section 5: Products or Services
+
+Certain products or services may be available exclusively online through the website. These products or services may have limited quantities and are subject to return or exchange only according to our Return Policy.
+
+We have made every effort to display as accurately as possible the colors and images of our products that appear at the store. We cannot guarantee that your computer monitor’s display of any color will be accurate.
+
+We reserve the right, but are not obligated, to limit the sales of our products or Services to any person, geographic region or jurisdiction. We may exercise this right on a case-by-case basis. We reserve the right to limit the quantities of any products or services that we offer. All descriptions of products or product pricing are subject to change at anytime without notice, at the sole discretion of us. We reserve the right to discontinue any product at any time. Any offer for any product or service made on this site is void where prohibited.
+
+We do not warrant that the quality of any products, services, information, or other material purchased or obtained by you will meet your expectations, or that any errors in the Service will be corrected.
+
+## Section 6: Accuracy of Billing and Account Information
+
+We reserve the right to refuse any order you place with us. We may, in our sole discretion, limit or cancel quantities purchased per person, per household or per order. These restrictions may include orders placed by or under the same customer account, the same credit card, and/or orders that use the same billing and/or shipping address. In the event that we make a change to or cancel an order, we may attempt to notify you by contacting the e-mail and/or billing address/phone number provided at the time the order was made. We reserve the right to limit or prohibit orders that, in our sole judgment, appear to be placed by dealers, resellers or distributors.
+
+You agree to provide current, complete and accurate purchase and account information for all purchases made at our store. You agree to promptly update your account and other information, including your email address and credit card numbers and expiration dates, so that we can complete your transactions and contact you as needed.
+
+For more detail, please review our Returns Policy.
+
+## Section 7: Optional Tools
+
+We may provide you with access to third-party tools over which we neither monitor nor have any control nor input.
+
+You acknowledge and agree that we provide access to such tools ”as is” and “as available” without any warranties, representations or conditions of any kind and without any endorsement. We shall have no liability whatsoever arising from or relating to your use of optional third-party tools.
+
+Any use by you of optional tools offered through the site is entirely at your own risk and discretion and you should ensure that you are familiar with and approve of the terms on which tools are provided by the relevant third-party provider(s).
+
+We may also, in the future, offer new services and/or features through the website (including, the release of new tools and resources). Such new features and/or services shall also be subject to these Terms of Service.
+
+## Section 8: Third-Party Links
+
+Certain content, products and services available via our Service may include materials from third-parties.
+
+Third-party links on this site may direct you to third-party websites that are not affiliated with us. We are not responsible for examining or evaluating the content or accuracy and we do not warrant and will not have any liability or responsibility for any third-party materials or websites, or for any other materials, products, or services of third-parties.
+
+We are not liable for any harm or damages related to the purchase or use of goods, services, resources, content, or any other transactions made in connection with any third-party websites. Please review carefully the third-party’s policies and practices and make sure you understand them before you engage in any transaction. Complaints, claims, concerns, or questions regarding third-party products should be directed to the third-party.
+
+## Section 9: User Comments, Feedback and Other Submissions
+
+If, at our request, you send certain specific submissions (for example contest entries) or without a request from us you send creative ideas, suggestions, proposals, plans, or other materials, whether online, by email, by postal mail, or otherwise (collectively, ‘comments’), you agree that we may, at any time, without restriction, edit, copy, publish, distribute, translate and otherwise use in any medium any comments that you forward to us. We are and shall be under no obligation (1) to maintain any comments in confidence; (2) to pay compensation for any comments; or (3) to respond to any comments.
+
+We may, but have no obligation to, monitor, edit or remove content that we determine in our sole discretion are unlawful, offensive, threatening, libelous, defamatory, pornographic, obscene or otherwise objectionable or violates any party’s intellectual property or these Terms of Service.
+
+You agree that your comments will not violate any right of any third-party, including copyright, trademark, privacy, personality or other personal or proprietary right. You further agree that your comments will not contain libelous or otherwise unlawful, abusive or obscene material, or contain any computer virus or other malware that could in any way affect the operation of the Service or any related website. You may not use a false e-mail address, pretend to be someone other than yourself, or otherwise mislead us or third-parties as to the origin of any comments. You are solely responsible for any comments you make and their accuracy. We take no responsibility and assume no liability for any comments posted by you or any third-party.
+
+## Section 10: Personal Information
+
+Your submission of personal information through the store is governed by our Privacy Policy.
+
+## Section 11: Errors, Inaccuracies and Omissions
+
+Occasionally there may be information on our site or in the Service that contains typographical errors, inaccuracies or omissions that may relate to product descriptions, pricing, promotions, offers, product shipping charges, transit times and availability. We reserve the right to correct any errors, inaccuracies or omissions, and to change or update information or cancel orders if any information in the Service or on any related website is inaccurate at any time without prior notice (including after you have submitted your order).
+
+## We undertake no obligation to update, amend or clarify information in the Service or on any related website, including without limitation, pricing information, except as required by law. No specified update or refresh date applied in the Service or on any related website, should be taken to indicate that all information in the Service or on any related website has been modified or updated.
+
+## Section 12: Prohibited Uses
+
+In addition to other prohibitions as set forth in the Terms of Service, you are prohibited from using the site or its content: (a) for any unlawful purpose; (b) to solicit others to perform or participate in any unlawful acts; (c) to violate any international, federal, provincial or state regulations, rules, laws, or local ordinances; (d) to infringe upon or violate our intellectual property rights or the intellectual property rights of others; (e) to harass, abuse, insult, harm, defame, slander, disparage, intimidate, or discriminate based on gender, sexual orientation, religion, ethnicity, race, age, national origin, or disability; (f) to submit false or misleading information; (g) to upload or transmit viruses or any other type of malicious code that will or may be used in any way that will affect the functionality or operation of the Service or of any related website, other websites, or the Internet; (h) to collect or track the personal information of others; (i) to spam, phish, pharm, pretext, spider, crawl, or scrape; (j) for any obscene or immoral purpose; or (k) to interfere with or circumvent the security features of the Service or any related website, other websites, or the Internet. We reserve the right to terminate your use of the Service or any related website for violating any of the prohibited uses.
+
+## Section 13: Disclaimer of Warranties; Limitation of Liability
+
+We do not guarantee, represent or warrant that your use of our service will be uninterrupted, timely, secure or error-free.
+
+We do not warrant that the results that may be obtained from the use of the service will be accurate or reliable.
+
+You agree that from time to time we may remove the service for indefinite periods of time or cancel the service at any time, without notice to you.
+
+You expressly agree that your use of, or inability to use, the service is at your sole risk. The service and all products and services delivered to you through the service are (except as expressly stated by us) provided ‘as is’ and ‘as available’ for your use, without any representation, warranties or conditions of any kind, either express or implied, including all implied warranties or conditions of merchantability, merchantable quality, fitness for a particular purpose, durability, title, and non-infringement.
+
+In no case shall Skill Recordings Inc., our directors, officers, employees, affiliates, agents, contractors, interns, suppliers, service providers or licensors be liable for any injury, loss, claim, or any direct, indirect, incidental, punitive, special, or consequential damages of any kind, including, without limitation lost profits, lost revenue, lost savings, loss of data, replacement costs, or any similar damages, whether based in contract, tort (including negligence), strict liability or otherwise, arising from your use of any of the service or any products procured using the service, or for any other claim related in any way to your use of the service or any product, including, but not limited to, any errors or omissions in any content, or any loss or damage of any kind incurred as a result of the use of the service or any content (or product) posted, transmitted, or otherwise made available via the service, even if advised of their possibility. Because some states or jurisdictions do not allow the exclusion or the limitation of liability for consequential or incidental damages, in such states or jurisdictions, our liability shall be limited to the maximum extent permitted by law.
+
+## Section 14: Indemnification
+
+You agree to indemnify, defend and hold harmless Skill Recordings Inc. and our parent, subsidiaries, affiliates, partners, officers, directors, agents, contractors, licensors, service providers, subcontractors, suppliers, interns and employees, harmless from any claim or demand, including reasonable attorneys’ fees, made by any third-party due to or arising out of your breach of these Terms of Service or the documents they incorporate by reference, or your violation of any law or the rights of a third-party.
+
+## Section 15: Severability
+
+In the event that any provision of these Terms of Service is determined to be unlawful, void or unenforceable, such provision shall nonetheless be enforceable to the fullest extent permitted by applicable law, and the unenforceable portion shall be deemed to be severed from these Terms of Service, such determination shall not affect the validity and enforceability of any other remaining provisions.
+
+## Section 16: Termination
+
+The obligations and liabilities of the parties incurred prior to the termination date shall survive the termination of this agreement for all purposes.
+
+These Terms of Service are effective unless and until terminated by either you or us. You may terminate these Terms of Service at any time by notifying us that you no longer wish to use our Services, or when you cease using our site.
+
+If in our sole judgment you fail, or we suspect that you have failed, to comply with any term or provision of these Terms of Service, we also may terminate this agreement at any time without notice and you will remain liable for all amounts due up to and including the date of termination; and/or accordingly may deny you access to our Services (or any part thereof).
+
+## Section 17: Entire Agreement
+
+The failure of us to exercise or enforce any right or provision of these Terms of Service shall not constitute a waiver of such right or provision.
+
+These Terms of Service and any policies or operating rules posted by us on this site or in respect to The Service constitutes the entire agreement and understanding between you and us and govern your use of the Service, superseding any prior or contemporaneous agreements, communications and proposals, whether oral or written, between you and us (including, but not limited to, any prior versions of the Terms of Service).
+Any ambiguities in the interpretation of these Terms of Service shall not be construed against the drafting party.
+
+## Section 18: Governing Law
+
+These Terms of Service and any separate agreements whereby we provide you Services shall be governed by and construed in accordance with the laws of 12333 Sowden Road, PMB#97429, Houston, TX, 77080, United States.
+
+## Section 19: Changes to Terms of Service
+
+You can review the most current version of the Terms of Service at any time at this page.
+
+We reserve the right, at our sole discretion, to update, change or replace any part of these Terms of Service by posting updates and changes to our website. It is your responsibility to check our website periodically for changes. Your continued use of or access to our website or the Service following the posting of any changes to these Terms of Service constitutes acceptance of those changes.
+
+## Section 20: Contact Information
+
+Questions about the Terms of Service should be sent to us at [${process.env.NEXT_PUBLIC_SUPPORT_EMAIL}](mailto:${process.env.NEXT_PUBLIC_SUPPORT_EMAIL}).
+
+## Refund Policy
+
+Our refund policy lasts 30 days. If 30 days have gone by since your purchase, unfortunately we can’t offer you a refund or exchange.
+
+There are certain situations where only partial refunds are granted: (if applicable)
+
+Any item not in its original condition, is damaged or missing parts for reasons not due to our error.
+
+Any item that is returned more than 30 days after delivery
+
+### Refunds (if applicable)
+
+We will notify you of the approval or rejection of your refund.
+
+If you are approved, then your refund will be processed, and a credit will automatically be applied to your credit card or original method of payment, within a certain amount of days.
+
+### Late or missing refunds (if applicable)
+
+If you haven’t received a refund yet, first check your bank account again. Then contact your credit card company, it may take some time before your refund is officially posted. Next contact your bank. There is often some processing time before a refund is posted. If you’ve done all of this and you still have not received your refund yet, please contact us at [${process.env.NEXT_PUBLIC_SUPPORT_EMAIL}](mailto:${process.env.NEXT_PUBLIC_SUPPORT_EMAIL}).
+
+### Sale items (if applicable)
+
+Only regular priced items may be refunded, unfortunately sale items cannot be refunded.
+
+## Privacy Policy
+
+This Privacy Policy describes how your personal information is collected, used, and shared when you visit or make a purchase from ${process.env.NEXT_PUBLIC_HOST} (the “Site”).
+
+### Personal Information We Collect
+
+When you visit the Site, we automatically collect certain information about your device, including information about your web browser, IP address, time zone, and some of the cookies that are installed on your device. Additionally, as you browse the Site, we collect information about the individual web pages or products that you view, what websites or search terms referred you to the Site, and information about how you interact with the Site. We refer to this automatically-collected information as “Device Information.”
+
+We collect Device Information using the following technologies:
+
+“Cookies” are data files that are placed on your device or computer and often include an anonymous unique identifier. For more information about cookies, and how to disable cookies, visit www.allaboutcookies.org.
+“Log files” track actions occurring on the Site, and collect data including your IP address, browser type, Internet service provider, referring/exit pages, and date/time stamps.
+
+“Web beacons,” “tags,” and “pixels” are electronic files used to record information about how you browse the Site.
+
+“Convertkit” to allow customers to subscribe for mailing list. Required information collected includes an email address. Optional information collected includes first name, last name, email address, phone number, birthday, and referral type.
+
+Additionally when you make a purchase or attempt to make a purchase through the Site, we collect certain information from you, including your name, billing address, shipping address, payment information (including credit card information), email address, and phone number. We refer to this information as “Order Information.”
+
+When we talk about “Personal Information” in this Privacy Policy, we are talking both about Device Information and Order Information.
+
+### How Do We Use Your Information?
+
+We use the Order Information that we collect generally to fulfill any orders placed through the Site (including processing your payment information, arranging for shipping, and providing you with invoices and/or order confirmations).
+
+Additionally, we use this Order Information to:
+
+### Communicate with you;
+
+Screen our orders for potential risk or fraud; and
+
+When in line with the preferences you have shared with us, provide you with information or advertising relating to our products or services.
+
+We use the Device Information that we collect to help us screen for potential risk and fraud (in particular, your IP address), and more generally to improve and optimize our Site (for example, by generating analytics about how our customers browse and interact with the Site, and to assess the success of our marketing and advertising campaigns).
+
+### Sharing Your Personal Information
+
+We use Google Analytics to help us understand how our customers use the Site. You can read more about how Google uses your Personal Information here: www.google.com/intl/en/policies/privacy
+
+You can also opt-out of Google Analytics here: www.tools.google.com/dlpage/gaoptout
+
+Finally, we may also share your Personal Information to comply with applicable laws and regulations, to respond to a subpoena, search warrant or other lawful request for information we receive, or to otherwise protect our rights.
+
+## Behavioral Advertising
+
+As described above, we use your Personal Information to provide you with targeted advertisements or marketing communications we believe may be of interest to you. For more information about how targeted advertising works, you can visit the Network Advertising Initiative’s (“NAI”) educational page at:
+
+www.networkadvertising.org/understanding-online-advertising/how-does-it-work
+
+Additionally, you can opt out of some of these services by visiting the Digital Advertising Alliance’s opt-out portal at: www.optout.aboutads.info.
+
+### Do Not Track
+
+Please note that we do not alter our Site’s data collection and use practices when we see a Do Not Track signal from your browser.
+
+## Changes
+
+We may update this privacy policy from time to time in order to reflect, for example, changes to our practices or for other operational, legal or regulatory reasons.
+
+## Contact Us
+
+For more information about our privacy practices, if you have questions, or if you would like to make a complaint, please contact us by e-mail at [${process.env.NEXT_PUBLIC_SUPPORT_EMAIL}](mailto:${process.env.NEXT_PUBLIC_SUPPORT_EMAIL}).
+`

--- a/apps/js-visualized/src/components/app/footer.tsx
+++ b/apps/js-visualized/src/components/app/footer.tsx
@@ -1,0 +1,14 @@
+import Link from 'next/link'
+
+export default function Footer() {
+	return (
+		<footer className="relative mx-auto flex w-full max-w-screen-lg flex-col items-start justify-between gap-16 px-5 pb-48 pt-14 sm:flex-row sm:px-10 sm:pt-16 lg:px-5">
+			<small className="text-muted-foreground absolute bottom-5 left-5 flex items-center gap-5 text-sm opacity-75">
+				<span>© JSVisualized.com</span>
+				<Link className=" transition hover:opacity-100" href="/privacy">
+					Terms & Conditions
+				</Link>
+			</small>
+		</footer>
+	)
+}

--- a/apps/js-visualized/src/components/app/layout.tsx
+++ b/apps/js-visualized/src/components/app/layout.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react'
 import { twMerge } from 'tailwind-merge'
 
+import Footer from './footer'
+
 export async function Layout({
 	children,
 	className,
@@ -18,6 +20,7 @@ export async function Layout({
 			>
 				{children}
 			</div>
+			<Footer />
 		</div>
 	)
 }

--- a/apps/pro-aws/src/app/page.tsx
+++ b/apps/pro-aws/src/app/page.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import Image from 'next/image'
+import Footer from '@/components/app/footer'
 import { PrimaryNewsletterCta } from '@/components/primary-newsletter-cta'
 import ReactMarkdown from 'react-markdown'
 import Balancer from 'react-wrap-balancer'
@@ -97,6 +98,7 @@ That's where ProAWS comes in. This isn't a typical AWS course. You won't study a
 					/>
 				</section>
 			</main>
+			<Footer />
 			<div aria-hidden="true" className="py-10" />
 		</div>
 	)

--- a/apps/pro-aws/src/components/app/footer.tsx
+++ b/apps/pro-aws/src/components/app/footer.tsx
@@ -1,0 +1,14 @@
+import Link from 'next/link'
+
+export default function Footer() {
+	return (
+		<footer className="relative mx-auto flex w-full max-w-screen-lg flex-col items-start justify-between gap-16 px-5 pb-48 pt-14 sm:flex-row sm:px-10 sm:pt-16 lg:px-5">
+			<small className="text-muted-foreground absolute bottom-5 left-5 flex items-center gap-5 text-sm opacity-75">
+				<span>© ProAWS.com</span>
+				<Link className=" transition hover:opacity-100" href="/privacy">
+					Terms & Conditions
+				</Link>
+			</small>
+		</footer>
+	)
+}

--- a/apps/total-node/src/app/page.tsx
+++ b/apps/total-node/src/app/page.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import type { Metadata, ResolvingMetadata } from 'next'
 import Image from 'next/image'
 import { PricingWidget } from '@/app/_components/home-pricing-widget'
+import Footer from '@/components/app/footer'
 import LandingCopy from '@/components/landing-copy'
 import { LandingHeroParallax } from '@/components/landing-hero-parallax'
 import { PrimaryNewsletterCta } from '@/components/primary-newsletter-cta'
@@ -143,6 +144,7 @@ const Home = async ({ searchParams }: Props) => {
 					</>
 				)}
 			</main>
+			<Footer />
 		</div>
 	)
 }

--- a/apps/total-node/src/components/app/footer.tsx
+++ b/apps/total-node/src/components/app/footer.tsx
@@ -1,0 +1,14 @@
+import Link from 'next/link'
+
+export default function Footer() {
+	return (
+		<footer className="relative mx-auto flex w-full max-w-screen-lg flex-col items-start justify-between gap-16 px-5 pb-48 pt-14 sm:flex-row sm:px-10 sm:pt-16 lg:px-5">
+			<small className="text-muted-foreground absolute bottom-5 left-5 flex items-center gap-5 text-sm opacity-75">
+				<span>© TotalNodeJS.com</span>
+				<Link className=" transition hover:opacity-100" href="/privacy">
+					Terms & Conditions
+				</Link>
+			</small>
+		</footer>
+	)
+}

--- a/apps/value-based-design/src/components/app/footer.tsx
+++ b/apps/value-based-design/src/components/app/footer.tsx
@@ -1,0 +1,17 @@
+import Link from 'next/link'
+
+export default function Footer() {
+	return (
+		<footer className="relative mx-auto flex w-full max-w-screen-lg flex-col items-start justify-between gap-16 px-5 pb-48 pt-14 sm:flex-row sm:px-10 sm:pt-16 lg:px-5">
+			<small className="absolute bottom-5 left-5 flex items-center gap-5">
+				<span className="opacity-75">© valuebased.design</span>
+				<Link
+					className="opacity-75 transition hover:opacity-100"
+					href="/privacy"
+				>
+					Terms & Conditions
+				</Link>
+			</small>
+		</footer>
+	)
+}

--- a/apps/value-based-design/src/components/layout.tsx
+++ b/apps/value-based-design/src/components/layout.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { usePathname } from 'next/navigation'
+import Footer from '@/components/app/footer'
 import Navigation from '@/components/navigation'
 
 import { cn } from '@coursebuilder/ui/utils/cn'
@@ -10,11 +11,17 @@ export const Layout = ({ children }: { children?: React.ReactNode }) => {
 	const isEditRoute = pathname.includes('/edit')
 
 	return (
-		<main
-			className={cn('flex min-h-[calc(100vh-var(--nav-height))] flex-col', {})}
-		>
-			<Navigation />
-			{children}
-		</main>
+		<>
+			<main
+				className={cn(
+					'flex min-h-[calc(100vh-var(--nav-height))] flex-col',
+					{},
+				)}
+			>
+				<Navigation />
+				{children}
+			</main>
+			<Footer />
+		</>
 	)
 }


### PR DESCRIPTION
added links to terms & conditions/privacy page for Value-based design, Astro.party, totalnode.js, pro-aws, and jsvisualized


<summary>

## screenshots
<details>

![Astro Party](https://github.com/user-attachments/assets/46057640-3aaf-49cd-902f-e1058d49f195)

![totalnodejs](https://github.com/user-attachments/assets/b52c8124-36bc-496e-a295-65a8aef4abc2)

![proaws](https://github.com/user-attachments/assets/2182e750-2d9f-4bca-aef3-7e652c4f9704)

![Value-Based Design](https://github.com/user-attachments/assets/42eb2048-0156-4ed6-907a-75b78d76bbf7)
</details>
</summary>

![gif](https://media1.giphy.com/media/e7yNPQmGUozyU/giphy.gif?cid=1927fc1byp4u5275o5neplq3tg17m1p0j244fphoteiqe1kq&ep=v1_gifs_search&rid=giphy.gif&ct=g)