### PR TITLE
feat(ai): add bluesky to share component

### DIFF
--- a/apps/ai-hero/src/components/share.tsx
+++ b/apps/ai-hero/src/components/share.tsx
@@ -35,6 +35,26 @@ export const Share = ({
 				aria-hidden="true"
 			/>
 			<a
+				href={`https://bsky.app/intent/compose?text=${encodeURIComponent(`${title ? `${title} ` : ''} by ${config.bluesky.handle} 
+        
+        ${url}`)}`}
+				target="_blank"
+				rel="noopener noreferrer"
+			>
+				<svg
+					width="20"
+					height="20"
+					viewBox="0 0 64 57"
+					fill="none"
+					xmlns="http://www.w3.org/2000/svg"
+				>
+					<path
+						fill="currentColor"
+						d="M13.873 3.805C21.21 9.332 29.103 20.537 32 26.55v15.882c0-.338-.13.044-.41.867-1.512 4.456-7.418 21.847-20.923 7.944-7.111-7.32-3.819-14.64 9.125-16.85-7.405 1.264-15.73-.825-18.014-9.015C1.12 23.022 0 8.51 0 6.55 0-3.268 8.579-.182 13.873 3.805ZM50.127 3.805C42.79 9.332 34.897 20.537 32 26.55v15.882c0-.338.13.044.41.867 1.512 4.456 7.418 21.847 20.923 7.944 7.111-7.32 3.819-14.64-9.125-16.85 7.405 1.264 15.73-.825 18.014-9.015C62.88 23.022 64 8.51 64 6.55c0-9.818-8.578-6.732-13.873-2.745Z"
+					/>
+				</svg>
+			</a>
+			<a
 				href={`https://x.com/intent/tweet?text=${encodeURIComponent(url + `${title ? `${title} ` : ''} by ${config.twitter.handle}`)}`}
 				target="_blank"
 				rel="noopener noreferrer"

--- a/apps/ai-hero/src/config.ts
+++ b/apps/ai-hero/src/config.ts
@@ -31,6 +31,9 @@ const config = {
 		cardType: 'summary_large_image',
 		handle: `@${process.env.NEXT_PUBLIC_PARTNER_TWITTER}`,
 	},
+	bluesky: {
+		handle: `@${process.env.NEXT_PUBLIC_PARTNER_BLUESKY}`,
+	},
 	sameAs: [`https://twitter.com/${process.env.NEXT_PUBLIC_PARTNER_TWITTER}`],
 	openGraph: {
 		type: 'website',


### PR DESCRIPTION
Adds a bluesky share button for ai-hero


![image](https://github.com/user-attachments/assets/0b259bd9-0458-4978-9a84-41db7519db1b)


![2025 The Year Building With GenAIs Gets Boring](https://github.com/user-attachments/assets/e977de61-76ad-4d8b-b71f-4fdd281dce34)


![gif](https://media3.giphy.com/media/Nf86uR0MRBdJAnL6X4/giphy.gif?cid=1927fc1byj8q2ffndwzxuya7jzmufnb75q3yuzh0t5chrtbk&ep=v1_gifs_search&rid=giphy.gif&ct=g)