### PR TITLE
chore: tighten up sync

### DIFF
--- a/apps/egghead/src/lib/posts.ts
+++ b/apps/egghead/src/lib/posts.ts
@@ -79,6 +79,7 @@ export const PostUpdateSchema = z.object({
 		title: z.string().min(2).max(90),
 		postType: PostTypeSchema.optional().default('lesson'),
 		body: z.string().optional().nullable(),
+		description: z.string().optional().nullable(),
 		visibility: PostVisibilitySchema.optional().default('public'),
 		state: PostStateSchema.optional().default('draft'),
 	}),


### PR DESCRIPTION
this keeps the sanity lesson and the egghead lesson updated when a coursebuilder change is made

some things to note:

* changes in sanity or egghead will NOT sync, use course builder
* we can do more here with transcripts
* video resources seem a little off to me and i only sync updates which replaces all resource in sanity but i **think** we don't need to think about videos in sanity going forward too much