### PR TITLE
feat(egh): Refactor Sanity Schema Types and Add Course Creation Function

### DIFF
--- a/apps/egghead/src/inngest/functions/sanity/create-course-in-sanity.ts
+++ b/apps/egghead/src/inngest/functions/sanity/create-course-in-sanity.ts
@@ -1,0 +1,68 @@
+import { POST_CREATED_EVENT } from '@/inngest/events/post-created'
+import { inngest } from '@/inngest/inngest.server'
+import { SanityCourseSchema } from '@/lib/sanity-content'
+import { createCourse, getSanityCollaborator } from '@/lib/sanity-content-query'
+import { loadEggheadInstructorForUser } from '@/lib/users'
+import { NonRetriableError } from 'inngest'
+
+export const createCourseInSanity = inngest.createFunction(
+	{
+		id: 'create-course-in-sanity',
+		name: 'Create Course in Sanity',
+	},
+	{
+		event: POST_CREATED_EVENT,
+	},
+	async ({ event, step }) => {
+		const post = await step.run('verify-post', async () => {
+			const { post } = event.data
+			if (!post) {
+				throw new NonRetriableError('Post not found')
+			}
+
+			if (post.fields?.postType !== 'course') {
+				throw new NonRetriableError('Post is not a course')
+			}
+
+			return post
+		})
+
+		const contributor = await step.run('get-contributor', async () => {
+			const instructor = await loadEggheadInstructorForUser(post.createdById)
+
+			if (!instructor) {
+				return null
+			}
+
+			const contributor = await getSanityCollaborator(instructor.id)
+
+			return contributor
+		})
+
+		const sanityCourse = await step.run('create-course', async () => {
+			const { fields } = post
+
+			const coursePayload = SanityCourseSchema.safeParse({
+				title: fields?.title,
+				slug: {
+					current: fields?.slug,
+					_type: 'slug',
+				},
+				description: fields?.body,
+				railsCourseId: fields?.railsCourseId,
+				collaborators: [contributor],
+				searchIndexingState: 'hidden',
+			})
+
+			if (!coursePayload.success) {
+				throw new NonRetriableError('Failed to create course in sanity', {
+					cause: coursePayload.error.flatten().fieldErrors,
+				})
+			}
+
+			const course = await createCourse(coursePayload.data)
+
+			return course
+		})
+	},
+)

--- a/apps/egghead/src/inngest/functions/sanity/create-course-in-sanity.ts
+++ b/apps/egghead/src/inngest/functions/sanity/create-course-in-sanity.ts
@@ -52,6 +52,9 @@ export const createCourseInSanity = inngest.createFunction(
 				railsCourseId: fields?.railsCourseId,
 				collaborators: [contributor],
 				searchIndexingState: 'hidden',
+				accessLevel: 'pro',
+				productionProcessState: 'new',
+				sharedId: post.id,
 			})
 
 			if (!coursePayload.success) {

--- a/apps/egghead/src/inngest/functions/sanity/sync-lesson-to-sanity.ts
+++ b/apps/egghead/src/inngest/functions/sanity/sync-lesson-to-sanity.ts
@@ -3,13 +3,12 @@ import { inngest } from '@/inngest/inngest.server'
 import { eggheadLessonSchema, getEggheadLesson } from '@/lib/egghead'
 import type { EggheadLesson } from '@/lib/egghead'
 import {
-	sanityReferenceSchema,
-	sanityVersionedSoftwareLibraryObjectSchema,
+	SanityReferenceSchema,
+	SoftwareLibraryArrayObjectSchema,
 } from '@/lib/sanity-content'
 import type {
-	SanityCollaboratorDocument,
 	SanityReference,
-	SanityVersionedSoftwareLibraryObject,
+	SoftwareLibraryArrayObject,
 } from '@/lib/sanity-content'
 import {
 	createSanityLesson,
@@ -36,7 +35,7 @@ export const syncLessonToSanity = inngest.createFunction(
 				try {
 					return await Promise.all(
 						lesson.topic_list.map(async (library: string) => {
-							return sanityVersionedSoftwareLibraryObjectSchema.parse(
+							return SoftwareLibraryArrayObjectSchema.parse(
 								await getSanitySoftwareLibrary(library),
 							)
 						}),
@@ -46,12 +45,12 @@ export const syncLessonToSanity = inngest.createFunction(
 					return []
 				}
 			},
-		)) as SanityVersionedSoftwareLibraryObject[]
+		)) as SoftwareLibraryArrayObject[]
 
 		const sanityCollaboratorReferenceObject = (await step.run(
 			'Get collaborator',
 			async () => {
-				return sanityReferenceSchema?.parse(
+				return SanityReferenceSchema?.parse(
 					await getSanityCollaborator(lesson.instructor.id),
 				)
 			},

--- a/apps/egghead/src/inngest/inngest.config.ts
+++ b/apps/egghead/src/inngest/inngest.config.ts
@@ -5,6 +5,7 @@ import { courseBuilderCoreFunctions } from '@coursebuilder/core/inngest'
 
 import { migrateTipsToPosts } from './functions/migrate-tips-to-posts'
 import { notifySlack } from './functions/notify-slack-for-post'
+import { createCourseInSanity } from './functions/sanity/create-course-in-sanity'
 import { syncLessonToSanity } from './functions/sanity/sync-lesson-to-sanity'
 import { syncVideoResourceToSanity } from './functions/sanity/sync-video-resource-to-sanity'
 import { syncPostToEgghead } from './functions/sync-post-to-egghead'
@@ -25,5 +26,6 @@ export const inngestConfig = {
 		notifySlack,
 		syncVideoResourceData,
 		syncPostsToEggheadLessons,
+		createCourseInSanity,
 	],
 }

--- a/apps/egghead/src/lib/posts-query.ts
+++ b/apps/egghead/src/lib/posts-query.ts
@@ -51,7 +51,7 @@ import {
 	updateEggheadLesson,
 	writeLegacyTaggingsToEgghead,
 } from './egghead'
-import { sanityLessonDocumentSchema } from './sanity-content'
+import { SanityLessonDocumentSchema } from './sanity-content'
 import {
 	replaceSanityLessonResources,
 	updateSanityLesson,
@@ -373,7 +373,7 @@ export async function writeNewPostToDatabase(input: {
 		: null
 
 	if (eggheadLessonId) {
-		const lesson = sanityLessonDocumentSchema.parse({
+		const lesson = SanityLessonDocumentSchema.parse({
 			_id: `lesson-${eggheadLessonId}`,
 			_type: 'lesson',
 			title,

--- a/apps/egghead/src/lib/sanity-content.ts
+++ b/apps/egghead/src/lib/sanity-content.ts
@@ -1,5 +1,35 @@
 import { z } from 'zod'
 
+export const ImageSchema = z.object({
+	_type: z.string().optional(),
+	label: z.string().optional(),
+	url: z.string().optional(),
+	_key: z.string().optional(),
+})
+export type Image = z.infer<typeof ImageSchema>
+
+export const SlugSchema = z.object({
+	current: z.string().optional(),
+	_type: z.string().optional(),
+})
+export type Slug = z.infer<typeof SlugSchema>
+
+export const SystemFieldsSchema = z.object({
+	_id: z.string().optional(),
+	_type: z.string().optional(),
+	_rev: z.string().optional(),
+	_createdAt: z.coerce.date().optional(),
+	_updatedAt: z.coerce.date().optional(),
+})
+export type SystemFields = z.infer<typeof SystemFieldsSchema>
+
+export const ReferenceSchema = z.object({
+	_ref: z.string().optional(),
+	_type: z.string().optional(),
+	_key: z.string().optional(),
+})
+export type Reference = z.infer<typeof ReferenceSchema>
+
 export const sanitySoftwareLibraryDocumentSchema = z.object({
 	_type: z.literal('software-library'),
 	_id: z.string(),
@@ -12,37 +42,22 @@ export type SanitySoftwareLibraryDocument = z.infer<
 	typeof sanitySoftwareLibraryDocumentSchema
 >
 
-export const sanityVersionedSoftwareLibraryObjectSchema = z.object({
-	_type: z.literal('versioned-software-library'),
-	_key: z.string(),
-	library: z.object({
-		_type: z.literal('reference'),
-		_ref: z.string(),
-	}),
-})
-
-export type SanityVersionedSoftwareLibraryObject = z.infer<
-	typeof sanityVersionedSoftwareLibraryObjectSchema
->
-
-export const sanityCollaboratorDocumentSchema = z.object({
-	_type: z.literal('collaborator'),
-	role: z.enum(['instructor', 'staff', 'illustrator']),
-	_id: z.string(),
-	eggheadInstructorId: z.string(),
-})
-
-export type SanityCollaboratorDocument = z.infer<
-	typeof sanityCollaboratorDocumentSchema
->
-
-export const sanityReferenceSchema = z.object({
+export const SanityReferenceSchema = z.object({
 	_type: z.literal('reference'),
 	_key: z.string(),
 	_ref: z.string(),
 })
 
-export type SanityReference = z.infer<typeof sanityReferenceSchema>
+export const SoftwareLibraryArrayObjectSchema = z.object({
+	_type: z.string().optional(),
+	_key: z.string().optional(),
+	library: ReferenceSchema.optional(),
+})
+export type SoftwareLibraryArrayObject = z.infer<
+	typeof SoftwareLibraryArrayObjectSchema
+>
+
+export type SanityReference = z.infer<typeof SanityReferenceSchema>
 
 export function createSanityReference(documentId: string): SanityReference {
 	return {
@@ -52,7 +67,7 @@ export function createSanityReference(documentId: string): SanityReference {
 	}
 }
 
-export const sanityVideoResourceDocumentSchema = z.object({
+export const SanityVideoResourceDocumentSchema = z.object({
 	_createdAt: z.string().datetime().nullish(),
 	_id: z.string().nullish(),
 	_rev: z.string().nullish(),
@@ -78,10 +93,10 @@ export const sanityVideoResourceDocumentSchema = z.object({
 })
 
 export type SanityVideoResourceDocument = z.infer<
-	typeof sanityVideoResourceDocumentSchema
+	typeof SanityVideoResourceDocumentSchema
 >
 
-export const sanityLessonDocumentSchema = z.object({
+export const SanityLessonDocumentSchema = z.object({
 	_type: z.literal('lesson'),
 	_id: z.string().nullish(),
 	title: z.string(),
@@ -91,18 +106,51 @@ export const sanityLessonDocumentSchema = z.object({
 	}),
 	description: z.string().nullish(),
 	railsLessonId: z.string().or(z.number()).nullish(),
-	softwareLibraries: z
-		.array(sanityVersionedSoftwareLibraryObjectSchema)
-		.nullish(),
-	collaborators: z.array(sanityReferenceSchema).nullish(),
+	softwareLibraries: z.array(SoftwareLibraryArrayObjectSchema).nullish(),
+	collaborators: z.array(SanityReferenceSchema).nullish(),
 	status: z.string().nullish(),
 	accessLevel: z.enum(['free', 'pro']).nullish(),
 })
 
-export type SanityLessonDocument = z.infer<typeof sanityLessonDocumentSchema>
+export type SanityLessonDocument = z.infer<typeof SanityLessonDocumentSchema>
 
 export const keyGenerator = () => {
 	return [...Array(12)]
 		.map(() => Math.floor(Math.random() * 16).toString(16))
 		.join('')
 }
+
+export const SanityCollaboratorSchema = z.object({
+	...SystemFieldsSchema.shape,
+	person: ReferenceSchema.optional(),
+	title: z.string().optional(),
+	eggheadInstructorId: z.string().optional(),
+	role: z.string().optional(),
+	department: z.string().optional(),
+})
+export type SanityCollaborator = z.infer<typeof SanityCollaboratorSchema>
+
+export const SanityCourseSchema = z.object({
+	...SystemFieldsSchema.shape,
+	title: z.string().optional(),
+	slug: SlugSchema.optional(),
+	summary: z.string().optional(),
+	description: z.string().optional(),
+	image: z.string().optional(),
+	images: z.array(ImageSchema).optional(),
+	imageIllustrator: ReferenceSchema.optional(),
+	accessLevel: z.string().optional(),
+	searchIndexingState: z.string().optional(),
+	productionProcessState: z.string().optional(),
+	railsCourseId: z.number().optional(),
+	sharedId: z.string().optional(),
+	softwareLibraries: z.array(SoftwareLibraryArrayObjectSchema).optional(),
+	collaborators: z
+		.array(ReferenceSchema)
+		.optional()
+		.or(SanityCollaboratorSchema)
+		.optional(),
+	resources: z.array(ReferenceSchema).optional(),
+})
+
+export type SanityCourse = z.infer<typeof SanityCourseSchema>


### PR DESCRIPTION
![of course](https://media3.giphy.com/media/PhTo1vmU7LnydQZPcl/giphy.gif?cid=01d288b0h7jb6lba8a63rxcricwxnset6cyd4ez5k7krjdkq&ep=v1_gifs_search&rid=giphy.gif&ct=g)

## What's Changed

This PR introduces a function for creating course documents in Sanity when a post with the "course" type is created. 

I've also brought in some new schemas and made types more consistent. 

### 1. New Course Creation Functionality
- Added `createCourseInSanity.ts` function to handle course creation in Sanity
- Integrated with POST_CREATED_EVENT to automatically create courses
- Added course creation function to inngest config

### 2. Schema Refactoring
- Consolidated and standardized Sanity schema types
- Introduced new base schemas (SystemFields, Reference, Image, Slug)
- Renamed schema constants to follow consistent PascalCase convention
- Added SanityCourse schema type and validation

### 3. Type Improvements
- Updated references to schema types
- Improved type safety with more specific schema definitions
- Renamed ambiguous type names for better clarity
