### PR TITLE
feat(egh): set up instructor invites table and dashboard

### DIFF
--- a/apps/egghead/src/app/admin/_components/instructor-data-table.tsx
+++ b/apps/egghead/src/app/admin/_components/instructor-data-table.tsx
@@ -107,12 +107,6 @@ const InstructorDataTable: React.FC<{ users: UserRow[] }> = ({ users }) => {
 						className="w-full max-w-sm pl-8"
 					/>
 				</div>
-				<Button
-					className="w-full disabled:cursor-not-allowed disabled:opacity-40 sm:w-auto"
-					disabled
-				>
-					<Plus className="mr-2 h-4 w-4" /> Add New Instructor
-				</Button>
 			</div>
 			<div className="rounded-md border">
 				<Table>

--- a/apps/egghead/src/app/admin/instructors/invite/_components/invite-instructor-form.tsx
+++ b/apps/egghead/src/app/admin/instructors/invite/_components/invite-instructor-form.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+
+import {
+	Button,
+	Form,
+	FormControl,
+	FormDescription,
+	FormField,
+	FormItem,
+	FormLabel,
+	FormMessage,
+	Input,
+} from '@coursebuilder/ui'
+
+import { inviteInstructor } from '../actions'
+
+const formSchema = z.object({
+	email: z.string().email(),
+})
+
+type FormValues = z.infer<typeof formSchema>
+
+export function InviteInstructorForm() {
+	const router = useRouter()
+	const form = useForm<FormValues>({
+		resolver: zodResolver(formSchema),
+		defaultValues: {
+			email: '',
+		},
+	})
+
+	const onSubmit = async (data: FormValues) => {
+		try {
+			await inviteInstructor(data.email)
+			router.refresh()
+			form.reset({ email: '' }, { keepDefaultValues: true })
+		} catch (error) {
+			console.error('Failed to invite instructor:', error)
+		}
+	}
+
+	return (
+		<div className="max-w-sm">
+			<h2 className="pb-4 text-lg font-bold">Invite New Instructor</h2>
+			<Form {...form}>
+				<form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+					<FormField
+						control={form.control}
+						name="email"
+						render={({ field }) => (
+							<FormItem>
+								<FormLabel className="sr-only">Email</FormLabel>
+								<FormControl>
+									<Input placeholder="email@example.com" {...field} />
+								</FormControl>
+								<FormDescription>
+									Enter the email of the instructor you want to invite.
+								</FormDescription>
+								<FormMessage />
+							</FormItem>
+						)}
+					/>
+					{(Object.keys(form.formState.dirtyFields).length > 0 ||
+						form.formState.isSubmitting) && (
+						<Button type="submit" disabled={form.formState.isSubmitting}>
+							Send Invite
+						</Button>
+					)}
+				</form>
+			</Form>
+		</div>
+	)
+}

--- a/apps/egghead/src/app/admin/instructors/invite/_components/invites-data-table.tsx
+++ b/apps/egghead/src/app/admin/instructors/invite/_components/invites-data-table.tsx
@@ -1,0 +1,291 @@
+'use client'
+
+import * as React from 'react'
+import Link from 'next/link'
+import {
+	ColumnDef,
+	flexRender,
+	getCoreRowModel,
+	getFilteredRowModel,
+	getPaginationRowModel,
+	getSortedRowModel,
+	PaginationState,
+	useReactTable,
+} from '@tanstack/react-table'
+import { format } from 'date-fns'
+import { ChevronDown, Plus, Search } from 'lucide-react'
+
+import {
+	Button,
+	DropdownMenu,
+	DropdownMenuCheckboxItem,
+	DropdownMenuContent,
+	DropdownMenuTrigger,
+	Input,
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from '@coursebuilder/ui'
+
+export const columns = () => {
+	return [
+		{
+			id: 'id',
+			header: 'ID',
+			accessorFn: (data) => data.id,
+		},
+		{
+			id: 'inviteState',
+			header: 'State',
+			accessorFn: (data) => data.inviteState,
+			cell: ({ row }) => {
+				return <div>{row.getValue('inviteState')}</div>
+			},
+		},
+		{
+			id: 'inviteEmail',
+			header: 'Invited Email',
+			accessorFn: (data) => data.inviteEmail,
+			cell: ({ row }) => {
+				return <div>{row.getValue('inviteEmail')}</div>
+			},
+		},
+		{
+			id: 'acceptedEmail',
+			header: 'Accepted Email',
+			accessorFn: (data) => data.acceptedEmail,
+			cell: ({ row }) => {
+				return <div>{row.getValue('acceptedEmail')}</div>
+			},
+		},
+		{
+			id: 'createdAt',
+			header: 'Created At',
+			accessorFn: (data) => data.createdAt,
+			cell: ({ row }) => {
+				const date = row.getValue('createdAt')
+				return date ? (
+					<div>{format(new Date(date), 'MMM d, yyyy h:mm a')}</div>
+				) : null
+			},
+		},
+		{
+			id: 'expiresAt',
+			header: 'Expires At',
+			accessorFn: (data) => data.expiresAt,
+			cell: ({ row }) => {
+				const date = row.getValue('expiresAt')
+				return date ? (
+					<div>{format(new Date(date), 'MMM d, yyyy h:mm a')}</div>
+				) : null
+			},
+		},
+		{
+			id: 'confirmedAt',
+			header: 'Confirmed At',
+			accessorFn: (data) => data.confirmedAt,
+			cell: ({ row }) => {
+				const date = row.getValue('confirmedAt')
+				return date ? (
+					<div>{format(new Date(date), 'MMM d, yyyy h:mm a')}</div>
+				) : null
+			},
+		},
+		{
+			id: 'completedAt',
+			header: 'Completed At',
+			accessorFn: (data) => data.completedAt,
+			cell: ({ row }) => {
+				const date = row.getValue('completedAt')
+				return date ? (
+					<div>{format(new Date(date), 'MMM d, yyyy h:mm a')}</div>
+				) : null
+			},
+		},
+	] as ColumnDef<InviteRow>[]
+}
+
+type InviteRow = {
+	id: string
+	inviteState: 'INITIATED' | 'VERIFIED' | 'CANCELED' | 'EXPIRED' | 'COMPLETED'
+	inviteEmail: string
+	acceptedEmail: string | null
+	userId: string | null
+	createdAt: Date | null
+	expiresAt: Date | null
+	canceledAt: Date | null
+	confirmedAt: Date | null
+	completedAt: Date | null
+}
+
+const InstructorDataTable: React.FC<{ invites: InviteRow[] }> = ({
+	invites,
+}) => {
+	const [pagination, setPagination] = React.useState<PaginationState>({
+		pageIndex: 0,
+		pageSize: 50,
+	})
+	const [globalFilter, setGlobalFilter] = React.useState<any>([])
+
+	const table = useReactTable<InviteRow>({
+		data: invites,
+		columns: columns(),
+		getCoreRowModel: getCoreRowModel(),
+		getPaginationRowModel: getPaginationRowModel(),
+		onPaginationChange: setPagination,
+		getSortedRowModel: getSortedRowModel(),
+		getFilteredRowModel: getFilteredRowModel(),
+		globalFilterFn: 'arrIncludes',
+		onGlobalFilterChange: setGlobalFilter,
+		state: {
+			pagination,
+			globalFilter,
+		},
+	})
+
+	return (
+		<div className="w-full max-w-screen-lg">
+			<h2 className="pb-4 text-lg font-bold">Current Invites</h2>
+			<div className="flex flex-col items-center justify-between gap-2 pb-4 sm:flex-row">
+				<div className="relative w-full">
+					<Search className="absolute left-2 top-3 h-4 w-4 text-gray-400" />
+					<Input
+						placeholder="Search invites..."
+						value={globalFilter}
+						onChange={(e) => table.setGlobalFilter(String(e.target.value))}
+						className="w-full max-w-sm pl-8"
+					/>
+				</div>
+				<DropdownMenu>
+					<DropdownMenuTrigger asChild>
+						<Button variant="outline" className="ml-auto">
+							Columns <ChevronDown className="ml-2 h-4 w-4" />
+						</Button>
+					</DropdownMenuTrigger>
+					<DropdownMenuContent align="end">
+						{table
+							.getAllColumns()
+							.filter((column) => column.getCanHide())
+							.map((column) => {
+								return (
+									<DropdownMenuCheckboxItem
+										key={column.id}
+										className="capitalize"
+										checked={column.getIsVisible()}
+										onCheckedChange={(value) =>
+											column.toggleVisibility(!!value)
+										}
+									>
+										{column.id}
+									</DropdownMenuCheckboxItem>
+								)
+							})}
+					</DropdownMenuContent>
+				</DropdownMenu>
+			</div>
+			<div className="rounded-md border">
+				<Table>
+					<TableHeader>
+						{table.getHeaderGroups().map((headerGroup) => (
+							<TableRow key={headerGroup.id}>
+								{headerGroup.headers.map((header) => {
+									return (
+										<TableHead key={header.id} className="whitespace-nowrap">
+											{header.isPlaceholder
+												? null
+												: flexRender(
+														header.column.columnDef.header,
+														header.getContext(),
+													)}
+										</TableHead>
+									)
+								})}
+							</TableRow>
+						))}
+					</TableHeader>
+					<TableBody>
+						{table.getRowModel().rows?.length ? (
+							table.getRowModel().rows.map((row) => (
+								<TableRow
+									key={row.id}
+									data-state={row.getIsSelected() && 'selected'}
+								>
+									{row.getVisibleCells().map((cell) => (
+										<TableCell className="whitespace-nowrap" key={cell.id}>
+											{flexRender(
+												cell.column.columnDef.cell,
+												cell.getContext(),
+											)}
+										</TableCell>
+									))}
+								</TableRow>
+							))
+						) : (
+							<TableRow>
+								<TableCell
+									colSpan={columns.length}
+									className="h-24 text-center"
+								>
+									No results.
+								</TableCell>
+							</TableRow>
+						)}
+					</TableBody>
+				</Table>
+			</div>
+			<div className="flex flex-col items-center justify-between gap-2 px-4 py-4 sm:flex-row">
+				<span className="flex items-center gap-1 text-xs opacity-50">
+					<div>Page</div>
+					<strong>
+						{table.getState().pagination.pageIndex + 1} of{' '}
+						{table.getPageCount().toLocaleString()}
+					</strong>
+				</span>
+				<div className="flex flex-col items-center justify-end gap-2 sm:flex-row">
+					{(table.getCanPreviousPage() || table.getCanNextPage()) && (
+						<div className="flex gap-2">
+							<Button
+								variant="outline"
+								size="sm"
+								onClick={() => table.previousPage()}
+								disabled={!table.getCanPreviousPage()}
+							>
+								Previous
+							</Button>
+							<Button
+								variant="outline"
+								size="sm"
+								onClick={() => table.nextPage()}
+								disabled={!table.getCanNextPage()}
+							>
+								Next
+							</Button>
+						</div>
+					)}
+					<select
+						value={table.getState().pagination.pageSize}
+						onChange={(e) => {
+							table.setPageSize(Number(e.target.value))
+						}}
+						className="ring-offset-background focus-visible:ring-ring border-input bg-background hover:bg-accent hover:text-accent-foreground inline-flex h-6 items-center justify-center whitespace-nowrap rounded-md border px-3 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
+					>
+						{[10, 25, 50, 100].map((pageSize) => (
+							<option
+								key={pageSize}
+								value={pageSize}
+								className="ring-offset-background focus-visible:ring-ring border-input bg-background hover:bg-accent hover:text-accent-foreground border text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
+							>
+								Show {pageSize}
+							</option>
+						))}
+					</select>
+				</div>
+			</div>
+		</div>
+	)
+}
+
+export default InstructorDataTable

--- a/apps/egghead/src/app/admin/instructors/invite/_components/invites-data-table.tsx
+++ b/apps/egghead/src/app/admin/instructors/invite/_components/invites-data-table.tsx
@@ -66,10 +66,8 @@ export const columns = () => {
 			header: 'Created At',
 			accessorFn: (data) => data.createdAt,
 			cell: ({ row }) => {
-				const date = row.getValue('createdAt')
-				return date ? (
-					<div>{format(new Date(date), 'MMM d, yyyy h:mm a')}</div>
-				) : null
+				const date = row.getValue('createdAt') as Date | null
+				return date ? <div>{format(date, 'MMM d, yyyy h:mm a')}</div> : null
 			},
 		},
 		{
@@ -77,10 +75,8 @@ export const columns = () => {
 			header: 'Expires At',
 			accessorFn: (data) => data.expiresAt,
 			cell: ({ row }) => {
-				const date = row.getValue('expiresAt')
-				return date ? (
-					<div>{format(new Date(date), 'MMM d, yyyy h:mm a')}</div>
-				) : null
+				const date = row.getValue('expiresAt') as Date | null
+				return date ? <div>{format(date, 'MMM d, yyyy h:mm a')}</div> : null
 			},
 		},
 		{
@@ -88,10 +84,8 @@ export const columns = () => {
 			header: 'Confirmed At',
 			accessorFn: (data) => data.confirmedAt,
 			cell: ({ row }) => {
-				const date = row.getValue('confirmedAt')
-				return date ? (
-					<div>{format(new Date(date), 'MMM d, yyyy h:mm a')}</div>
-				) : null
+				const date = row.getValue('confirmedAt') as Date | null
+				return date ? <div>{format(date, 'MMM d, yyyy h:mm a')}</div> : null
 			},
 		},
 		{
@@ -99,10 +93,8 @@ export const columns = () => {
 			header: 'Completed At',
 			accessorFn: (data) => data.completedAt,
 			cell: ({ row }) => {
-				const date = row.getValue('completedAt')
-				return date ? (
-					<div>{format(new Date(date), 'MMM d, yyyy h:mm a')}</div>
-				) : null
+				const date = row.getValue('completedAt') as Date | null
+				return date ? <div>{format(date, 'MMM d, yyyy h:mm a')}</div> : null
 			},
 		},
 	] as ColumnDef<InviteRow>[]

--- a/apps/egghead/src/app/admin/instructors/invite/actions.ts
+++ b/apps/egghead/src/app/admin/instructors/invite/actions.ts
@@ -1,0 +1,11 @@
+'use server'
+
+import { INSTRUCTOR_INVITE_CREATED_EVENT } from '@/inngest/events/instructor-invite-created'
+import { inngest } from '@/inngest/inngest.server'
+
+export async function inviteInstructor(email: string) {
+	await inngest.send({
+		name: INSTRUCTOR_INVITE_CREATED_EVENT,
+		data: { email },
+	})
+}

--- a/apps/egghead/src/app/admin/instructors/invite/page.tsx
+++ b/apps/egghead/src/app/admin/instructors/invite/page.tsx
@@ -1,0 +1,29 @@
+import { Suspense } from 'react'
+import { notFound } from 'next/navigation'
+import { db } from '@/db'
+import { invites } from '@/db/schema'
+import { getServerAuthSession } from '@/server/auth'
+
+import { InviteInstructorForm } from './_components/invite-instructor-form'
+import InvitesDataTable from './_components/invites-data-table'
+
+export default async function InstructorsPage() {
+	const { ability } = await getServerAuthSession()
+	if (!ability.can('manage', 'all')) {
+		notFound()
+	}
+	const instructorInvites = await db.select().from(invites)
+
+	return (
+		<>
+			<h1 className="mb-8 mt-10 text-3xl font-bold text-gray-800 dark:text-gray-200">
+				Instructor Invites
+			</h1>
+			<InviteInstructorForm />
+			<hr className="my-8" />
+			<Suspense fallback={<div>Loading...</div>}>
+				<InvitesDataTable invites={instructorInvites} />
+			</Suspense>
+		</>
+	)
+}

--- a/apps/egghead/src/app/admin/layout.tsx
+++ b/apps/egghead/src/app/admin/layout.tsx
@@ -8,13 +8,18 @@ import {
 	SidebarProvider,
 	SidebarTrigger,
 } from '@/components/ui/sidebar'
-import { MicIcon, TagIcon } from 'lucide-react'
+import { MailIcon, MicIcon, TagIcon } from 'lucide-react'
 
 const adminSidebar = [
 	{
 		label: 'Instructors',
 		href: '/admin/instructors',
 		icon: MicIcon,
+	},
+	{
+		label: 'Instructor Invites',
+		href: '/admin/instructors/invite',
+		icon: MailIcon,
 	},
 	{
 		label: 'Tags',

--- a/apps/egghead/src/db/schema.ts
+++ b/apps/egghead/src/db/schema.ts
@@ -1,6 +1,13 @@
 import { mysqlTable } from '@/db/mysql-table'
+import {
+	getInvitesRelationsSchema,
+	getInvitesSchema,
+} from '@/db/schemas/invites'
 
 import { getCourseBuilderSchema } from '@coursebuilder/adapter-drizzle/mysql'
+
+export const invites = getInvitesSchema(mysqlTable)
+export const invitesRelations = getInvitesRelationsSchema(mysqlTable)
 
 export const {
 	accounts,

--- a/apps/egghead/src/db/schemas/invites.ts
+++ b/apps/egghead/src/db/schemas/invites.ts
@@ -1,0 +1,67 @@
+import { users } from '@/db/schema'
+import { relations } from 'drizzle-orm'
+import {
+	int,
+	mysqlEnum,
+	MySqlTableFn,
+	timestamp,
+	varchar,
+} from 'drizzle-orm/mysql-core'
+import { sql } from 'drizzle-orm/sql'
+import { z } from 'zod'
+
+export const inviteSchema = z.object({
+	id: z.string().max(191),
+	inviteState: z.enum([
+		'INITIATED',
+		'VERIFIED',
+		'CANCELED',
+		'EXPIRED',
+		'COMPLETED',
+	]),
+	inviteEmail: z.string().max(191),
+	acceptedEmail: z.string().max(191),
+	userId: z.string().max(255),
+	createdAt: z.date().nullable(),
+	expiresAt: z.date().nullable(),
+	canceledAt: z.date().nullable(),
+	confirmedAt: z.date().nullable(),
+	completedAt: z.date().nullable(),
+})
+
+export function getInvitesSchema(mysqlTable: MySqlTableFn) {
+	return mysqlTable('Invite', {
+		id: varchar('id', { length: 191 }).primaryKey(),
+		inviteState: mysqlEnum('inviteState', [
+			'INITIATED',
+			'VERIFIED',
+			'CANCELED',
+			'EXPIRED',
+			'COMPLETED',
+		])
+			.default('INITIATED')
+			.notNull()
+			.$type<'INITIATED' | 'VERIFIED' | 'CANCELED' | 'EXPIRED' | 'COMPLETED'>(),
+		inviteEmail: varchar('inviteEmail', { length: 191 }).notNull(),
+		acceptedEmail: varchar('acceptedEmail', { length: 191 }),
+		userId: varchar('userId', { length: 255 }),
+		createdAt: timestamp('createdAt').defaultNow(),
+		expiresAt: timestamp('expiresAt').default(
+			sql`(CURRENT_TIMESTAMP + INTERVAL 7 DAY)`,
+		),
+		canceledAt: timestamp('canceledAt'),
+		confirmedAt: timestamp('confirmedAt'),
+		completedAt: timestamp('completedAt'),
+	})
+}
+
+export function getInvitesRelationsSchema(mysqlTable: MySqlTableFn) {
+	const invites = getInvitesSchema(mysqlTable)
+
+	return relations(invites, ({ one }) => ({
+		user: one(users, {
+			fields: [invites.userId],
+			references: [users.id],
+		}),
+	}))
+}

--- a/apps/egghead/src/inngest/events/instructor-invite-created.ts
+++ b/apps/egghead/src/inngest/events/instructor-invite-created.ts
@@ -1,0 +1,7 @@
+export const INSTRUCTOR_INVITE_CREATED_EVENT = 'instructor/invite/created'
+export type InstructorInviteCreated = {
+	name: typeof INSTRUCTOR_INVITE_CREATED_EVENT
+	data: {
+		email: string
+	}
+}

--- a/apps/egghead/src/inngest/functions/instructor-invite-created.ts
+++ b/apps/egghead/src/inngest/functions/instructor-invite-created.ts
@@ -1,0 +1,55 @@
+import { db } from '@/db'
+import { communicationPreferences, invites, userRoles } from '@/db/schema'
+import BasicEmail from '@/emails/basic-email'
+import { INSTRUCTOR_INVITE_CREATED_EVENT } from '@/inngest/events/instructor-invite-created'
+import { inngest } from '@/inngest/inngest.server'
+import { sendAnEmail } from '@/utils/send-an-email'
+import { NonRetriableError } from 'inngest'
+import { customAlphabet } from 'nanoid'
+
+const nanoid = customAlphabet('1234567890abcdefghijklmnopqrstuvwxyz', 5)
+
+export const instructorInviteCreated = inngest.createFunction(
+	{
+		id: `instructor invite created`,
+		name: 'Instructor Invite Created',
+	},
+	{
+		event: INSTRUCTOR_INVITE_CREATED_EVENT,
+	},
+	async ({ event, step }) => {
+		// const email = {
+		// 	body: `{{user.email}} signed up.`,
+		// 	subject: 'egghead Post Builder Signup from {{user.email}}',
+		// }
+
+		await step.run('create invite', async () => {
+			const invite = await db.insert(invites).values({
+				id: nanoid(),
+				inviteState: 'INITIATED',
+				inviteEmail: event.data.email,
+				createdAt: new Date(),
+			})
+
+			return invite
+		})
+
+		// const sendResponse = await step.run('send the email', async () => {
+		// 	return await sendAnEmail({
+		// 		Component: BasicEmail,
+		// 		componentProps: {
+		// 			body: email.body,
+		// 		},
+		// 		Subject: email.subject,
+		// 		To: event.user.email,
+		// 		type: 'broadcast',
+		// 	})
+		// })
+
+		return {
+			// sendResponse,
+			// email,
+			email: event.data.email,
+		}
+	},
+)

--- a/apps/egghead/src/inngest/inngest.config.ts
+++ b/apps/egghead/src/inngest/inngest.config.ts
@@ -3,6 +3,7 @@ import { inngest } from '@/inngest/inngest.server'
 
 import { courseBuilderCoreFunctions } from '@coursebuilder/core/inngest'
 
+import { instructorInviteCreated } from './functions/instructor-invite-created'
 import { migrateTipsToPosts } from './functions/migrate-tips-to-posts'
 import { notifySlack } from './functions/notify-slack-for-post'
 import { syncLessonToSanity } from './functions/sanity/sync-lesson-to-sanity'
@@ -25,5 +26,6 @@ export const inngestConfig = {
 		notifySlack,
 		syncVideoResourceData,
 		syncPostsToEggheadLessons,
+		instructorInviteCreated,
 	],
 }

--- a/apps/egghead/src/inngest/inngest.server.ts
+++ b/apps/egghead/src/inngest/inngest.server.ts
@@ -24,6 +24,10 @@ import {
 	EGGHEAD_LESSON_CREATED_EVENT,
 	EggheadLessonCreated,
 } from './events/egghead/lesson-created'
+import {
+	INSTRUCTOR_INVITE_CREATED_EVENT,
+	InstructorInviteCreated,
+} from './events/instructor-invite-created'
 import { POST_CREATED_EVENT, PostCreated } from './events/post-created'
 import {
 	TIPS_UPDATED_EVENT,
@@ -48,6 +52,7 @@ export type Events = {
 	[EGGHEAD_LESSON_CREATED_EVENT]: EggheadLessonCreated
 	[POST_CREATED_EVENT]: PostCreated
 	[SYNC_POSTS_TO_EGGHEAD_LESSONS_EVENT]: SyncPostsToEggheadLessonsEvent
+	[INSTRUCTOR_INVITE_CREATED_EVENT]: InstructorInviteCreated
 }
 
 const callbackBase =


### PR DESCRIPTION
This enables working on the instructor invites project [EGG-389](https://linear.app/skillrecordings/issue/EGG-389/invite-instructors-through-course-builder) by setting up an invites table that will track the state of an invite as it's sent out and accepted by instructor. The invites table is set up to be local to egghead course builder only under `db/schemas`

This also sets up UI to send those invites out for admin:
![image](https://github.com/user-attachments/assets/3a495bc5-5537-4e43-97ef-b7358583ff59)

## TODO
- [ ] open deploy request for egghead database

![gif](https://media1.giphy.com/media/507EfBfD16YzrK6TGz/giphy.gif?cid=1927fc1bjgomsb6zwn6yq7mr8ax2jp825h1vq1wx9iutmhb1&ep=v1_gifs_search&rid=giphy.gif&ct=g)
