### PR TITLE
fix: Improve Lesson Upsert to Typesense

### DIFF
--- a/apps/egghead/src/lib/egghead.ts
+++ b/apps/egghead/src/lib/egghead.ts
@@ -146,7 +146,7 @@ export async function updateEggheadLesson(input: {
 	duration: number
 	hlsUrl?: string
 	body?: string
-	published_at?: number
+	published_at?: string
 }) {
 	const {
 		eggheadLessonId,
@@ -270,6 +270,10 @@ export const eggheadLessonSchema = z.object({
 	state: z.string(),
 	instructor: z.object({
 		id: z.number(),
+		name: z.string(),
+		url: z.string().url(),
+		avatar_url: z.string().url(),
+		avatar_file_name: z.string(),
 	}),
 })
 

--- a/apps/egghead/src/lib/egghead.ts
+++ b/apps/egghead/src/lib/egghead.ts
@@ -146,6 +146,7 @@ export async function updateEggheadLesson(input: {
 	duration: number
 	hlsUrl?: string
 	body?: string
+	published_at?: number
 }) {
 	const {
 		eggheadLessonId,
@@ -158,6 +159,7 @@ export async function updateEggheadLesson(input: {
 		slug,
 		guid,
 		body = '',
+		published_at = null,
 	} = input
 	await eggheadPgQuery(
 		`UPDATE lessons SET
@@ -171,7 +173,8 @@ export async function updateEggheadLesson(input: {
 			guid = $7,
 			summary = $8,
       is_pro_content = $10,
-      free_forever = NOT $10
+      free_forever = NOT $10,
+      published_at = $11
 		WHERE id = $9`,
 		[
 			state,
@@ -184,6 +187,7 @@ export async function updateEggheadLesson(input: {
 			body,
 			eggheadLessonId,
 			access,
+			published_at,
 		],
 	)
 }

--- a/apps/egghead/src/lib/posts-query.ts
+++ b/apps/egghead/src/lib/posts-query.ts
@@ -57,7 +57,7 @@ import {
 	updateSanityLesson,
 } from './sanity-content-query'
 import { EggheadTag, EggheadTagSchema } from './tags'
-import { upsertPostToTypeSense } from './typesense'
+import { upsertPostToTypeSense } from './typesense-query'
 
 export async function searchLessons(searchTerm: string) {
 	const { session } = await getServerAuthSession()
@@ -518,7 +518,7 @@ export async function writePostUpdateToDatabase(input: {
 				hlsUrl: `https://stream.mux.com/${videoResource.muxPlaybackId}.m3u8`,
 			}),
 			...(action === 'publish' && {
-				published_at: Date.now(),
+				published_at: new Date().toISOString(),
 			}),
 		})
 	}

--- a/apps/egghead/src/lib/posts-query.ts
+++ b/apps/egghead/src/lib/posts-query.ts
@@ -517,6 +517,9 @@ export async function writePostUpdateToDatabase(input: {
 			...(videoResource?.muxPlaybackId && {
 				hlsUrl: `https://stream.mux.com/${videoResource.muxPlaybackId}.m3u8`,
 			}),
+			...(action === 'publish' && {
+				published_at: Date.now(),
+			}),
 		})
 	}
 

--- a/apps/egghead/src/lib/typesense-query.ts
+++ b/apps/egghead/src/lib/typesense-query.ts
@@ -1,0 +1,94 @@
+import Typesense from 'typesense'
+
+import { getEggheadLesson } from './egghead'
+import { Post, PostAction } from './posts'
+import { getPostTags } from './posts-query'
+import { InstructorSchema, TypesensePostSchema } from './typesense'
+
+export async function upsertPostToTypeSense(post: Post, action: PostAction) {
+	let client = new Typesense.Client({
+		nodes: [
+			{
+				host: process.env.NEXT_PUBLIC_TYPESENSE_HOST!,
+				port: 443,
+				protocol: 'https',
+			},
+		],
+		apiKey: process.env.TYPESENSE_WRITE_API_KEY!,
+		connectionTimeoutSeconds: 2,
+	})
+
+	const shouldIndex =
+		post.fields.state === 'published' && post.fields.visibility === 'public'
+
+	if (!shouldIndex) {
+		await client
+			.collections(process.env.TYPESENSE_COLLECTION_NAME!)
+			.documents(String(post.fields.eggheadLessonId))
+			.delete()
+			.catch((err) => {
+				console.error(err)
+			})
+	} else {
+		if (!post.fields.eggheadLessonId) {
+			return
+		}
+
+		const lesson = await getEggheadLesson(post.fields.eggheadLessonId)
+
+		console.log('lesson', lesson)
+
+		const instructor = InstructorSchema.parse({
+			id: lesson.instructor?.id,
+			name: lesson.instructor?.full_name,
+			first_name: lesson.instructor?.first_name,
+			last_name: lesson.instructor?.last_name,
+			url: lesson.instructor?.url,
+			avatar_url: lesson.instructor?.avatar_url,
+		})
+
+		const tags = await getPostTags(post.id)
+
+		const resource = TypesensePostSchema.safeParse({
+			id: `${post.fields.eggheadLessonId}`,
+			externalId: post.id,
+			title: post.fields.title,
+			slug: post.fields.slug,
+			summary: post.fields.description,
+			description: post.fields.body,
+			name: post.fields.title,
+			path: `/${post.fields.slug}`,
+			type: post.fields.postType,
+			_tags: tags.map((tag) => tag.fields.name),
+			...(lesson && {
+				instructor_name: lesson.instructor?.full_name,
+				instructor,
+				image: lesson.image_480_url,
+				published_at_timestamp: lesson.published_at
+					? new Date(lesson.published_at).getTime()
+					: null,
+			}),
+		})
+
+		if (!resource.success) {
+			console.error(resource.error)
+			return
+		}
+
+		console.log('resource', resource.data)
+
+		await client
+			.collections(process.env.TYPESENSE_COLLECTION_NAME!)
+			.documents()
+			.upsert({
+				...resource.data,
+				...(action === 'publish' && {
+					published_at_timestamp: post.updatedAt?.getTime() ?? Date.now(),
+				}),
+				updated_at_timestamp: post.updatedAt?.getTime() ?? Date.now(),
+			})
+			.catch((err) => {
+				console.error(err)
+			})
+	}
+}


### PR DESCRIPTION
![zardoz](https://media1.tenor.com/m/gbp3dhLF9ykAAAAd/zardoz.gif)

## What Changed

- Added schema validation for Typesense documents using Zod
- Split Typesense logic into separate query and schema files
- Added `published_at` field support in egghead lesson updates
- Enhanced instructor metadata in Typesense documents
- Added tags to Typesense documents

## Why

These changes improve the reliability and maintainability of our Typesense integration:

1. Schema validation ensures we're sending valid data to Typesense
2. Better organization of code with separate schema and query files
3. Proper tracking of publish dates for content
4. Trimmed TypeSense records down to what was needed

## Issues

[EGG-392: Lessons previously published via course builder have null published_at attributes](https://linear.app/skillrecordings/issue/EGG-392/lessons-previously-published-via-course-builder-have-null-published-at)
