### PR TITLE
feat(aih): org billing management

### DIFF
--- a/apps/ai-hero/e2e/sample-test.spec.ts
+++ b/apps/ai-hero/e2e/sample-test.spec.ts
@@ -1,0 +1,7 @@
+import { expect, test } from '@playwright/test'
+
+test('home page shows main heading and subscribe button', async ({ page }) => {
+	await page.goto('/')
+
+	await expect(page.getByRole('button', { name: 'Subscribe' })).toBeVisible()
+})

--- a/apps/ai-hero/package.json
+++ b/apps/ai-hero/package.json
@@ -21,7 +21,8 @@
 		"start": "next start",
 		"typecheck": "tsc --noEmit",
 		"index-typesense": "tsx ./scripts/index-content.ts",
-		"test": "vitest run -c vitest.config.ts"
+		"test": "vitest run -c vitest.config.ts",
+		"test:e2e": "playwright test"
 	},
 	"dependencies": {
 		"@amplitude/analytics-browser": "^2.6.1",
@@ -69,6 +70,7 @@
 		"@next/third-parties": "15.0.2",
 		"@pinecone-database/pinecone": "^2.1.0",
 		"@planetscale/database": "1.19.0",
+		"@playwright/test": "^1.46.1",
 		"@react-email/components": "0.0.27",
 		"@react-email/markdown": "^0.0.11",
 		"@react-email/render": "1.0.2",
@@ -107,6 +109,7 @@
 		"crypto": "^1.0.1",
 		"date-fns": "^2.30.0",
 		"date-fns-tz": "^2.0.1",
+		"dotenv": "^10.0.0",
 		"dotenv-flow": "^4.1.0",
 		"drizzle-orm": "0.36.0",
 		"feed": "^4.2.2",

--- a/apps/ai-hero/package.json
+++ b/apps/ai-hero/package.json
@@ -202,6 +202,7 @@
 		"@types/styled-components": "^5.1.29",
 		"autoprefixer": "^10.4.14",
 		"concurrently": "^8.2.2",
+		"dotenv-cli": "^7.3.0",
 		"drizzle-kit": "0.27.1",
 		"encoding": "^0.1.13",
 		"eslint": "^8.47.0",

--- a/apps/ai-hero/package.json
+++ b/apps/ai-hero/package.json
@@ -20,7 +20,8 @@
 		"lint": "next lint",
 		"start": "next start",
 		"typecheck": "tsc --noEmit",
-		"index-typesense": "tsx ./scripts/index-content.ts"
+		"index-typesense": "tsx ./scripts/index-content.ts",
+		"test": "vitest run -c vitest.config.ts"
 	},
 	"dependencies": {
 		"@amplitude/analytics-browser": "^2.6.1",
@@ -198,7 +199,7 @@
 		"@types/styled-components": "^5.1.29",
 		"autoprefixer": "^10.4.14",
 		"concurrently": "^8.2.2",
-		"dotenv-cli": "^7.3.0",
+		"dotenv-cli": "^7.4.1",
 		"drizzle-kit": "0.27.1",
 		"encoding": "^0.1.13",
 		"eslint": "^8.47.0",
@@ -213,7 +214,8 @@
 		"tailwind-scrollbar": "^3.0.0",
 		"tailwindcss": "^3.3.3",
 		"tsx": "^4.7.1",
-		"typescript": "5.4.5"
+		"typescript": "5.4.5",
+		"vite-tsconfig-paths": "^5.1.4"
 	},
 	"ct3aMetadata": {
 		"initVersion": "7.22.0"

--- a/apps/ai-hero/package.json
+++ b/apps/ai-hero/package.json
@@ -202,7 +202,6 @@
 		"@types/styled-components": "^5.1.29",
 		"autoprefixer": "^10.4.14",
 		"concurrently": "^8.2.2",
-		"dotenv-cli": "^7.4.1",
 		"drizzle-kit": "0.27.1",
 		"encoding": "^0.1.13",
 		"eslint": "^8.47.0",

--- a/apps/ai-hero/package.json
+++ b/apps/ai-hero/package.json
@@ -109,7 +109,6 @@
 		"crypto": "^1.0.1",
 		"date-fns": "^2.30.0",
 		"date-fns-tz": "^2.0.1",
-		"dotenv": "^10.0.0",
 		"dotenv-flow": "^4.1.0",
 		"drizzle-orm": "0.36.0",
 		"feed": "^4.2.2",

--- a/apps/ai-hero/playwright.config.ts
+++ b/apps/ai-hero/playwright.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig, devices } from '@playwright/test'
+import * as dotenv from 'dotenv'
+
+dotenv.config({ path: './env.local' })
+
+export default defineConfig({
+	testDir: './e2e',
+	fullyParallel: true,
+	forbidOnly: !!process.env['CI'],
+	retries: process.env['CI'] ? 2 : 0,
+	workers: process.env['CI'] ? 1 : 3,
+	reporter: 'html',
+	use: {
+		baseURL: 'https://joel-x42.coursebuilder.dev',
+		trace: 'on-first-retry',
+	},
+	projects: [
+		{
+			name: 'chromium',
+			use: { ...devices['Desktop Chrome'] },
+		},
+		{
+			name: 'firefox',
+			use: { ...devices['Desktop Firefox'] },
+		},
+		{
+			name: 'webkit',
+			use: { ...devices['Desktop Safari'] },
+		},
+	],
+	webServer: {
+		command: 'pnpm start',
+		url: 'https://joel-x42.coursebuilder.dev',
+		reuseExistingServer: !process.env['CI'],
+	},
+})

--- a/apps/ai-hero/playwright.config.ts
+++ b/apps/ai-hero/playwright.config.ts
@@ -1,7 +1,4 @@
 import { defineConfig, devices } from '@playwright/test'
-import * as dotenv from 'dotenv'
-
-dotenv.config({ path: './env.local' })
 
 export default defineConfig({
 	testDir: './e2e',

--- a/apps/ai-hero/src/ability/index.ts
+++ b/apps/ai-hero/src/ability/index.ts
@@ -97,7 +97,7 @@ export function getAbilityRules(options: GetAbilityOptions = {}) {
 
 	if (options.user) {
 		if (options.user.roles.map((role) => role.name).includes('admin')) {
-			// can('manage', 'all')
+			can('manage', 'all')
 		}
 
 		if (options.user.roles.map((role) => role.name).includes('contributor')) {

--- a/apps/ai-hero/src/ability/purchase-validators.test.ts
+++ b/apps/ai-hero/src/ability/purchase-validators.test.ts
@@ -58,7 +58,7 @@ test('has no available seats if a purchase exists with a bulk coupon without sea
 })
 
 test('has a valid purchase', () => {
-	const purchases = [{}] as Purchase[]
+	const purchases = [{ status: 'Valid' }] as Purchase[]
 	expect(hasValidPurchase(purchases)).toBe(true)
 })
 

--- a/apps/ai-hero/src/app/(organization)/organization-list/page.tsx
+++ b/apps/ai-hero/src/app/(organization)/organization-list/page.tsx
@@ -1,0 +1,58 @@
+import { headers } from 'next/headers'
+import Link from 'next/link'
+import { courseBuilderAdapter } from '@/db'
+import { getServerAuthSession } from '@/server/auth'
+
+import {
+	Button,
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from '@coursebuilder/ui'
+
+export default async function OrganizationList() {
+	const { session } = await getServerAuthSession()
+	const headersList = await headers()
+
+	const currentOrganization = headersList.get('x-organization-id')
+
+	if (!session?.user) {
+		return <div>You must be logged in to view this page</div>
+	}
+
+	const organizationMemberships =
+		await courseBuilderAdapter.getMembershipsForUser(session.user.id)
+
+	return (
+		<div className="container mx-auto space-y-6 py-8">
+			<div className="flex flex-col gap-2">
+				<h1 className="text-3xl font-bold tracking-tight">Organizations</h1>
+			</div>
+			<div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+				{organizationMemberships.map((membership) => (
+					<Card key={membership.organizationId} className="block">
+						<CardHeader>
+							<CardTitle>
+								{membership.organization.name || 'Unnamed Organization'}
+							</CardTitle>
+							<CardDescription>Role: {membership.role}</CardDescription>
+						</CardHeader>
+						{currentOrganization === membership.organizationId ? (
+							<CardContent>
+								<p className="text-muted-foreground text-sm">
+									Current organization
+								</p>
+							</CardContent>
+						) : (
+							<CardContent>
+								<Button>Switch to this organization</Button>
+							</CardContent>
+						)}
+					</Card>
+				))}
+			</div>
+		</div>
+	)
+}

--- a/apps/ai-hero/src/app/(organization)/settings/billing/page.tsx
+++ b/apps/ai-hero/src/app/(organization)/settings/billing/page.tsx
@@ -1,0 +1,216 @@
+import { Metadata } from 'next'
+import { headers } from 'next/headers'
+import { redirect } from 'next/navigation'
+import { stripeProvider } from '@/coursebuilder/stripe-provider'
+import { courseBuilderAdapter, db } from '@/db'
+import { subscription as subscriptionTable } from '@/db/schema'
+import { getServerAuthSession } from '@/server/auth'
+import { subject } from '@casl/ability'
+import { eq } from 'drizzle-orm'
+import type Stripe from 'stripe'
+
+import { Subscription } from '@coursebuilder/core/schemas/subscription'
+
+export const metadata: Metadata = {
+	title: 'Organization Billing',
+	description: 'Manage organization billing and subscription',
+}
+
+export default async function BillingPage() {
+	const { session, ability } = await getServerAuthSession()
+	const headersList = await headers()
+	const organizationId = headersList.get('x-organization-id')
+
+	if (!organizationId || !session?.user?.id) {
+		return redirect('/login')
+	}
+
+	if (
+		!ability.can(
+			'read',
+			subject('OrganizationBilling', {
+				organizationId,
+			}),
+		)
+	) {
+		throw new Error('Unauthorized')
+	}
+
+	const organization =
+		await courseBuilderAdapter.getOrganization(organizationId)
+
+	if (!organization) {
+		throw new Error('Organization not found')
+	}
+
+	// Get organization subscription
+	const activeSubscription = (await db.query.subscription.findFirst({
+		where: (subscription, { eq, and }) =>
+			and(
+				eq(subscription.organizationId, organizationId),
+				eq(subscription.status, 'active'),
+			),
+		with: {
+			merchantSubscription: true,
+		},
+	})) as Subscription | null
+
+	const stripeSubscription = activeSubscription?.merchantSubscription
+		?.identifier
+		? ((await stripeProvider.getSubscription(
+				activeSubscription.merchantSubscription.identifier,
+			)) as Stripe.Subscription)
+		: null
+
+	const currentPrice = stripeSubscription?.items.data[0]?.price
+	const productName =
+		typeof currentPrice?.product === 'string'
+			? '' // Handle string case - could fetch product details if needed
+			: // @ts-ignore
+				currentPrice?.product?.name || 'Unknown Plan'
+	const paymentMethod =
+		stripeSubscription?.default_payment_method as Stripe.PaymentMethod
+
+	if (activeSubscription && stripeSubscription) {
+		if (stripeSubscription.status !== activeSubscription.status) {
+			await db
+				.update(subscriptionTable)
+				.set({
+					status: stripeSubscription.status,
+					fields: {
+						...activeSubscription.fields,
+						stripeStatus: stripeSubscription.status,
+						currentPeriodEnd: stripeSubscription.current_period_end,
+						priceId: currentPrice?.id,
+					},
+				})
+				.where(eq(subscriptionTable.id, activeSubscription.id))
+		}
+	}
+
+	return (
+		<main className="container mx-auto px-4 py-8">
+			<div className="mx-auto max-w-4xl">
+				<h1 className="mb-8 text-3xl font-bold">Billing & Subscription</h1>
+
+				<div className="divide-y divide-gray-200 rounded-lg bg-white shadow">
+					{/* Current Plan */}
+					<div className="p-6">
+						<h2 className="text-lg font-medium text-gray-900">Current Plan</h2>
+						<div className="mt-4">
+							{stripeSubscription ? (
+								<>
+									<div className="flex items-center justify-between">
+										<div>
+											<p className="text-sm font-medium text-gray-500">Plan</p>
+											<p className="text-lg font-medium text-gray-900">
+												{productName}
+											</p>
+										</div>
+										<button
+											type="button"
+											className="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50"
+										>
+											Change Plan
+										</button>
+									</div>
+									<div className="mt-4">
+										<p className="text-sm font-medium text-gray-500">Status</p>
+										<p className="text-lg font-medium text-gray-900">
+											{stripeSubscription.status}
+										</p>
+									</div>
+									<div className="mt-4">
+										<p className="text-sm font-medium text-gray-500">
+											Next Billing Date
+										</p>
+										<p className="text-lg font-medium text-gray-900">
+											{new Date(
+												stripeSubscription.current_period_end * 1000,
+											).toLocaleDateString()}
+										</p>
+									</div>
+									{currentPrice && (
+										<div className="mt-4">
+											<p className="text-sm font-medium text-gray-500">
+												Amount
+											</p>
+											<p className="text-lg font-medium text-gray-900">
+												${(currentPrice.unit_amount! / 100).toFixed(2)}/
+												{currentPrice.recurring?.interval}
+											</p>
+										</div>
+									)}
+								</>
+							) : (
+								<div className="py-4 text-center">
+									<p className="text-sm text-gray-500">
+										No active subscription
+									</p>
+									<button
+										type="button"
+										className="mt-4 inline-flex items-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700"
+									>
+										Subscribe Now
+									</button>
+								</div>
+							)}
+						</div>
+					</div>
+
+					{/* Payment Method */}
+					{stripeSubscription && (
+						<div className="p-6">
+							<h2 className="text-lg font-medium text-gray-900">
+								Payment Method
+							</h2>
+							<div className="mt-4">
+								<div className="flex items-center justify-between">
+									<div className="flex items-center">
+										<div className="text-sm text-gray-500">
+											{paymentMethod?.card ? (
+												<>
+													<span className="font-medium">
+														{paymentMethod.card.brand.toUpperCase()}
+													</span>
+													<span className="ml-2">
+														•••• {paymentMethod.card.last4}
+													</span>
+													<span className="ml-2">
+														Expires {paymentMethod.card.exp_month}/
+														{paymentMethod.card.exp_year}
+													</span>
+												</>
+											) : (
+												'No payment method on file'
+											)}
+										</div>
+									</div>
+									<button
+										type="button"
+										className="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50"
+									>
+										Update Payment Method
+									</button>
+								</div>
+							</div>
+						</div>
+					)}
+
+					{/* Billing History */}
+					<div className="p-6">
+						<h2 className="text-lg font-medium text-gray-900">
+							Billing History
+						</h2>
+						<div className="mt-4">
+							{/* Billing history table would go here */}
+							<p className="text-sm text-gray-500">
+								No billing history available
+							</p>
+						</div>
+					</div>
+				</div>
+			</div>
+		</main>
+	)
+}

--- a/apps/ai-hero/src/inngest/functions/stripe/event-subscription-checkout-session-completed.ts
+++ b/apps/ai-hero/src/inngest/functions/stripe/event-subscription-checkout-session-completed.ts
@@ -1,0 +1,224 @@
+import { inngest } from '@/inngest/inngest.server'
+
+import { NEW_SUBSCRIPTION_CREATED_EVENT } from '@coursebuilder/core/inngest/commerce/event-new-subscription-created'
+import { STRIPE_CHECKOUT_SESSION_COMPLETED_EVENT } from '@coursebuilder/core/inngest/stripe/event-checkout-session-completed'
+import { parseSubscriptionInfoFromCheckoutSession } from '@coursebuilder/core/lib/pricing/stripe-subscription-utils'
+import { User } from '@coursebuilder/core/schemas'
+import { checkoutSessionCompletedEvent } from '@coursebuilder/core/schemas/stripe/checkout-session-completed'
+
+export const stripeSubscriptionCheckoutSessionComplete = inngest.createFunction(
+	{
+		id: 'stripe-subscription-checkout-session-completed',
+		name: 'Stripe Subscription Checkout Session Completed',
+	},
+	{
+		event: STRIPE_CHECKOUT_SESSION_COMPLETED_EVENT,
+		if: "event.data.stripeEvent.data.object.mode == 'subscription'",
+	},
+	async ({ event, step, db, paymentProvider }) => {
+		const stripeEvent = checkoutSessionCompletedEvent.parse(
+			event.data.stripeEvent,
+		)
+		const paymentsAdapter = paymentProvider.options.paymentsAdapter
+		const stripeCheckoutSession = stripeEvent.data.object
+
+		const merchantAccount = await step.run(
+			'load the merchant account',
+			async () => {
+				return await db.getMerchantAccount({
+					provider: 'stripe',
+				})
+			},
+		)
+
+		if (!merchantAccount) {
+			throw new Error('Merchant account not found')
+		}
+
+		const checkoutSession = await step.run(
+			'get stripe checkout session',
+			async () => {
+				return await paymentsAdapter.getCheckoutSession(
+					stripeCheckoutSession.id,
+				)
+			},
+		)
+
+		if (checkoutSession.mode === 'subscription') {
+			const subscriptionInfo = await step.run(
+				'parse checkout session for subscription',
+				async () => {
+					return await parseSubscriptionInfoFromCheckoutSession(checkoutSession)
+				},
+			)
+
+			const { user, isNewUser } = await step.run('load the user', async () => {
+				if (!subscriptionInfo.email) {
+					throw new Error('subscriptionInfo.email is null')
+				}
+				return await db.findOrCreateUser(subscriptionInfo.email)
+			})
+
+			const organization = await step.run('load the organization', async () => {
+				if (
+					subscriptionInfo.metadata?.organizationId &&
+					subscriptionInfo.metadata?.organizationId !== 'undefined'
+				) {
+					return await db.getOrganization(
+						subscriptionInfo.metadata.organizationId,
+					)
+				}
+
+				const memberships = await db.getMembershipsForUser(user.id)
+				if (memberships.length === 1) {
+					const organizationId = memberships[0]?.organizationId
+
+					if (!organizationId) {
+						throw new Error('organizationId is null')
+					}
+					return await db.getOrganization(organizationId)
+				}
+
+				if (memberships.length > 1) {
+					throw new Error(
+						'user has more than one organization and not specified in metadata',
+					)
+				}
+
+				const personalOrganization = await db.createOrganization({
+					name: `Personal (${user.email})`,
+				})
+
+				if (!personalOrganization) {
+					throw new Error('Failed to create personal organization')
+				}
+
+				const membership = await db.addMemberToOrganization({
+					organizationId: personalOrganization.id,
+					userId: user.id,
+					invitedById: user.id,
+				})
+
+				if (!membership) {
+					throw new Error('Failed to add user to personal organization')
+				}
+
+				await db.addRoleForMember({
+					organizationId: personalOrganization.id,
+					memberId: membership.id,
+					role: 'owner',
+				})
+
+				return personalOrganization
+			})
+
+			if (!organization) {
+				throw new Error('organization is null')
+			}
+
+			await step.run('store the checkout session', async () => {
+				await db.createMerchantSession({
+					merchantAccountId: merchantAccount.id,
+					identifier: stripeCheckoutSession.id,
+					organizationId: organization.id,
+				})
+			})
+
+			const merchantProduct = await step.run(
+				'load the merchant product',
+				async () => {
+					if (!subscriptionInfo.productIdentifier) {
+						throw new Error('subscriptionInfo.productIdentifier is null')
+					}
+					return await db.getMerchantProduct(subscriptionInfo.productIdentifier)
+				},
+			)
+
+			const merchantCustomer = await step.run(
+				'load the merchant customer',
+				async () => {
+					if (!subscriptionInfo.customerIdentifier) {
+						throw new Error('subscriptionInfo.customerIdentifier is null')
+					}
+					return await db.findOrCreateMerchantCustomer({
+						user: user as User,
+						identifier: subscriptionInfo.customerIdentifier,
+						merchantAccountId: merchantAccount.id,
+					})
+				},
+			)
+
+			if (!merchantCustomer) {
+				throw new Error('merchantCustomer is null')
+			}
+
+			if (!merchantProduct) {
+				throw new Error('merchantProduct is null')
+			}
+
+			const { subscription } = await step.run(
+				'create a merchant subscription',
+				async () => {
+					const merchantSubscription = await db.createMerchantSubscription({
+						merchantAccountId: merchantAccount.id,
+						merchantCustomerId: merchantCustomer.id,
+						merchantProductId: merchantProduct.id,
+						identifier: subscriptionInfo.subscriptionIdentifier,
+					})
+
+					if (!merchantSubscription) {
+						throw new Error('merchantSubscription is null')
+					}
+
+					const subscription = await db.createSubscription({
+						merchantSubscriptionId: merchantSubscription.id,
+						organizationId: organization.id,
+						productId: merchantProduct.productId,
+					})
+
+					return { subscription, merchantSubscription }
+				},
+			)
+
+			await step.run('give member learner role', async () => {
+				if (!user) {
+					throw new Error('user is null')
+				}
+				if (!organization) {
+					throw new Error('organization is null')
+				}
+
+				const userMemberships = await db.getMembershipsForUser(user.id)
+
+				const organizationMembership = userMemberships.find(
+					(membership) => membership.organizationId === organization.id,
+				)
+
+				if (!organizationMembership) {
+					throw new Error('organizationMembership is null')
+				}
+
+				await db.addRoleForMember({
+					memberId: organizationMembership.id,
+					organizationId: organization.id,
+					role: 'learner',
+				})
+			})
+
+			if (!subscription) {
+				throw new Error('subscription is null')
+			}
+
+			await step.sendEvent(NEW_SUBSCRIPTION_CREATED_EVENT, {
+				name: NEW_SUBSCRIPTION_CREATED_EVENT,
+				data: {
+					subscriptionId: subscription.id,
+					checkoutSessionId: stripeCheckoutSession.id,
+				},
+				user,
+			})
+
+			return { subscription, subscriptionInfo }
+		}
+	},
+)

--- a/apps/ai-hero/src/inngest/inngest.config.ts
+++ b/apps/ai-hero/src/inngest/inngest.config.ts
@@ -20,6 +20,7 @@ import { courseBuilderCoreFunctions } from '@coursebuilder/core/inngest'
 
 import { getOrCreateConcept } from './functions/concepts/get-or-create-tag'
 import { computeVideoSplitPoints } from './functions/split_video'
+import { stripeSubscriptionCheckoutSessionComplete } from './functions/stripe/event-subscription-checkout-session-completed'
 
 export const inngestConfig = {
 	client: inngest,
@@ -45,5 +46,6 @@ export const inngestConfig = {
 		noProgressContinued,
 		syncPurchaseTags,
 		addPurchasesConvertkit,
+		stripeSubscriptionCheckoutSessionComplete,
 	],
 }

--- a/apps/ai-hero/src/inngest/inngest.server.ts
+++ b/apps/ai-hero/src/inngest/inngest.server.ts
@@ -42,6 +42,10 @@ import {
 	ResourceChat,
 } from '@coursebuilder/core/inngest/co-gardener/resource-chat'
 import { createInngestMiddleware } from '@coursebuilder/core/inngest/create-inngest-middleware'
+import {
+	STRIPE_CHECKOUT_SESSION_COMPLETED_EVENT,
+	StripeCheckoutSessionCompleted,
+} from '@coursebuilder/core/inngest/stripe/event-checkout-session-completed'
 import DeepgramProvider from '@coursebuilder/core/providers/deepgram'
 import OpenAIProvider from '@coursebuilder/core/providers/openai'
 import PartykitProvider from '@coursebuilder/core/providers/partykit'
@@ -76,6 +80,7 @@ export type Events = {
 	[OAUTH_PROVIDER_ACCOUNT_LINKED_EVENT]: OauthProviderAccountLinked
 	[NO_PROGRESS_MADE_EVENT]: NoProgressMade
 	[SYNC_PURCHASE_TAGS_EVENT]: SyncPurchaseTags
+	[STRIPE_CHECKOUT_SESSION_COMPLETED_EVENT]: StripeCheckoutSessionCompleted
 }
 
 const callbackBase =

--- a/apps/ai-hero/src/lib/organizations.ts
+++ b/apps/ai-hero/src/lib/organizations.ts
@@ -1,0 +1,20 @@
+import { courseBuilderAdapter } from '@/db'
+import { getServerAuthSession } from '@/server/auth'
+
+export async function getOrganizations() {
+	const { session } = await getServerAuthSession()
+
+	if (!session?.user?.id) {
+		throw new Error('Not authenticated')
+	}
+
+	const memberships = await courseBuilderAdapter.getMembershipsForUser(
+		session.user.id,
+	)
+
+	return memberships.map((membership) => ({
+		id: membership.organizationId,
+		name: membership.organization.name || 'Unnamed Organization',
+		slug: membership.organization.fields?.slug || membership.organizationId,
+	}))
+}

--- a/apps/ai-hero/src/middleware.ts
+++ b/apps/ai-hero/src/middleware.ts
@@ -43,6 +43,6 @@ export default auth(async function middleware(req) {
 
 export const config = {
 	matcher: [
-		'/((?!api|_next/static|_next/image|favicon.ico|_axiom/web-vitals).*)',
+		'/((?!api|_next/static|_next/image|favicon.ico|_axiom/web-vitals|sitemap.xml|robots.txt).*)',
 	],
-} as const
+}

--- a/apps/ai-hero/src/middleware.ts
+++ b/apps/ai-hero/src/middleware.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from 'next/server'
+
+import { auth } from './server/auth'
+import { AuthUser, determineOrgAccess } from './utils/determine-org-access'
+
+const COOKIE_OPTIONS = {
+	httpOnly: true,
+	secure: process.env.NODE_ENV === 'production',
+	sameSite: 'lax' as const,
+	maxAge: 60 * 60 * 24 * 90,
+	path: '/',
+} as const
+
+export default auth(async function middleware(req) {
+	const user = req.auth?.user as AuthUser | undefined
+	if (!user) return NextResponse.next()
+
+	const currentOrgId = req.cookies.get('organizationId')?.value
+	const response = NextResponse.next()
+
+	const result = determineOrgAccess(user.organizationRoles, currentOrgId)
+
+	if (result.action === 'REDIRECT_TO_ORG_LIST') {
+		return NextResponse.redirect(new URL('/organization-list', req.url))
+	}
+
+	if (result.action === 'SET_OWNER_ORG' && result.organizationId) {
+		response.cookies.set(
+			'organizationId',
+			result.organizationId,
+			COOKIE_OPTIONS,
+		)
+		response.headers.set('x-organization-id', result.organizationId)
+		return response
+	}
+
+	if (result.organizationId) {
+		response.headers.set('x-organization-id', result.organizationId)
+	}
+
+	return response
+})
+
+export const config = {
+	matcher: [
+		'/((?!api|_next/static|_next/image|favicon.ico|_axiom/web-vitals).*)',
+	],
+} as const

--- a/apps/ai-hero/src/utils/determine-org-access.test.ts
+++ b/apps/ai-hero/src/utils/determine-org-access.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+
+import { determineOrgAccess, OrganizationRole } from './determine-org-access'
+
+describe('determineOrgAccess', () => {
+	const createRole = (
+		overrides: Partial<OrganizationRole> = {},
+	): OrganizationRole => ({
+		active: true,
+		name: 'member',
+		organizationId: 'org-1',
+		...overrides,
+	})
+
+	it('redirects when no roles exist', () => {
+		expect(determineOrgAccess([], 'org-1')).toEqual({
+			action: 'REDIRECT_TO_ORG_LIST',
+		})
+	})
+
+	it('redirects when roles exist but none are active', () => {
+		const roles = [createRole({ active: false })]
+		expect(determineOrgAccess(roles, 'org-1')).toEqual({
+			action: 'REDIRECT_TO_ORG_LIST',
+		})
+	})
+
+	it('redirects when no matching org role and no owner role', () => {
+		const roles = [createRole({ organizationId: 'org-2' })]
+		expect(determineOrgAccess(roles, 'org-1')).toEqual({
+			action: 'REDIRECT_TO_ORG_LIST',
+		})
+	})
+
+	it('uses owner org when no valid current role exists', () => {
+		const roles = [
+			createRole({ name: 'owner', organizationId: 'owner-org' }),
+			createRole({ organizationId: 'org-2' }),
+		]
+		expect(determineOrgAccess(roles, 'org-1')).toEqual({
+			action: 'SET_OWNER_ORG',
+			organizationId: 'owner-org',
+		})
+	})
+
+	it('uses current org when valid role exists', () => {
+		const roles = [createRole()]
+		expect(determineOrgAccess(roles, 'org-1')).toEqual({
+			action: 'USE_CURRENT_ORG',
+			organizationId: 'org-1',
+		})
+	})
+
+	it('prefers current org over owner org when both exist', () => {
+		const roles = [
+			createRole(),
+			createRole({ name: 'owner', organizationId: 'owner-org' }),
+		]
+		expect(determineOrgAccess(roles, 'org-1')).toEqual({
+			action: 'USE_CURRENT_ORG',
+			organizationId: 'org-1',
+		})
+	})
+
+	it('handles undefined currentOrgId', () => {
+		const roles = [createRole({ name: 'owner', organizationId: 'owner-org' })]
+		expect(determineOrgAccess(roles, undefined)).toEqual({
+			action: 'SET_OWNER_ORG',
+			organizationId: 'owner-org',
+		})
+	})
+})

--- a/apps/ai-hero/src/utils/determine-org-access.ts
+++ b/apps/ai-hero/src/utils/determine-org-access.ts
@@ -1,0 +1,49 @@
+export type OrgAuthResult = {
+	action: 'REDIRECT_TO_ORG_LIST' | 'SET_OWNER_ORG' | 'USE_CURRENT_ORG'
+	organizationId?: string
+}
+
+export type OrganizationRole = {
+	active: boolean
+	name: string
+	organizationId: string
+}
+
+export type AuthUser = {
+	organizationRoles: OrganizationRole[]
+}
+
+export function determineOrgAccess(
+	roles: OrganizationRole[],
+	currentOrgId?: string,
+): OrgAuthResult {
+	const { ownerRole, hasValidCurrentOrgRole } = roles.reduce(
+		(acc, role) => {
+			if (!role.active) return acc
+			if (role.name === 'owner') acc.ownerRole = role
+			if (currentOrgId && role.organizationId === currentOrgId)
+				acc.hasValidCurrentOrgRole = true
+			return acc
+		},
+		{
+			ownerRole: null as OrganizationRole | null,
+			hasValidCurrentOrgRole: false,
+		},
+	)
+
+	if (!hasValidCurrentOrgRole && !ownerRole) {
+		return { action: 'REDIRECT_TO_ORG_LIST' }
+	}
+
+	if (!hasValidCurrentOrgRole && ownerRole) {
+		return {
+			action: 'SET_OWNER_ORG',
+			organizationId: ownerRole.organizationId,
+		}
+	}
+
+	return {
+		action: 'USE_CURRENT_ORG',
+		organizationId: currentOrgId,
+	}
+}

--- a/apps/ai-hero/vitest.config.ts
+++ b/apps/ai-hero/vitest.config.ts
@@ -1,0 +1,28 @@
+/// <reference types="vitest" />
+import tsconfigPaths from 'vite-tsconfig-paths'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+	test: {
+		include: ['src/**/*.{test,spec}.{ts,tsx}'],
+		exclude: ['node_modules', '.next'],
+		globals: true,
+		coverage: {
+			provider: 'v8',
+			reporter: ['text', 'json', 'html'],
+			exclude: [
+				'node_modules/**',
+				'.next/**',
+				'**/*.d.ts',
+				'**/*.config.*',
+				'**/types/*',
+			],
+		},
+	},
+	plugins: [tsconfigPaths()],
+	resolve: {
+		alias: {
+			'@': '/src',
+		},
+	},
+})

--- a/packages/adapter-drizzle/src/lib/mysql/schemas/org/organization-membership-roles.ts
+++ b/packages/adapter-drizzle/src/lib/mysql/schemas/org/organization-membership-roles.ts
@@ -10,6 +10,7 @@ import {
 
 import { getRolesSchema } from '../auth/roles.js'
 import { getOrganizationMembershipsSchema } from './organization-memberships.js'
+import { getOrganizationsSchema } from './organizations.js'
 
 export function getOrganizationMembershipRolesSchema(mysqlTable: MySqlTableFn) {
 	return mysqlTable(
@@ -53,6 +54,7 @@ export function getOrganizationMembershipRolesRelationsSchema(
 		getOrganizationMembershipRolesSchema(mysqlTable)
 	const organizationMemberships = getOrganizationMembershipsSchema(mysqlTable)
 	const roles = getRolesSchema(mysqlTable)
+	const organizations = getOrganizationsSchema(mysqlTable)
 	return relations(organizationMembershipRoles, ({ one }) => ({
 		organizationMembership: one(organizationMemberships, {
 			fields: [organizationMembershipRoles.organizationMembershipId],
@@ -63,6 +65,11 @@ export function getOrganizationMembershipRolesRelationsSchema(
 			fields: [organizationMembershipRoles.roleId],
 			references: [roles.id],
 			relationName: 'role',
+		}),
+		organization: one(organizations, {
+			fields: [organizationMembershipRoles.organizationId],
+			references: [organizations.id],
+			relationName: 'organization',
 		}),
 	}))
 }

--- a/packages/adapter-drizzle/src/lib/mysql/schemas/org/organization-memberships.ts
+++ b/packages/adapter-drizzle/src/lib/mysql/schemas/org/organization-memberships.ts
@@ -10,6 +10,7 @@ import {
 
 import { getUsersSchema } from '../auth/users.js'
 import { getPurchaseSchema } from '../commerce/purchase.js'
+import { getOrganizationMembershipRolesSchema } from './organization-membership-roles.js'
 import { getOrganizationsSchema } from './organizations.js'
 
 export function getOrganizationMembershipsSchema(mysqlTable: MySqlTableFn) {
@@ -47,6 +48,8 @@ export function getOrganizationMembershipsRelationsSchema(
 	const organizationMemberships = getOrganizationMembershipsSchema(mysqlTable)
 	const purchases = getPurchaseSchema(mysqlTable)
 	const organizations = getOrganizationsSchema(mysqlTable)
+	const organizationMembershipRoles =
+		getOrganizationMembershipRolesSchema(mysqlTable)
 
 	return relations(organizationMemberships, ({ one, many }) => ({
 		user: one(users, {
@@ -64,6 +67,9 @@ export function getOrganizationMembershipsRelationsSchema(
 			fields: [organizationMemberships.organizationId],
 			references: [organizations.id],
 			relationName: 'organization',
+		}),
+		organizationMembershipRoles: many(organizationMembershipRoles, {
+			relationName: 'organizationMembership',
 		}),
 	}))
 }

--- a/packages/core/src/inngest/commerce/event-purchase-status-updated.ts
+++ b/packages/core/src/inngest/commerce/event-purchase-status-updated.ts
@@ -1,6 +1,3 @@
-import { NonRetriableError } from 'inngest'
-import { isEmpty } from 'lodash'
-import pluralize from 'pluralize'
 import { z } from 'zod'
 
 import {

--- a/packages/core/src/inngest/commerce/send-creator-slack-notification.ts
+++ b/packages/core/src/inngest/commerce/send-creator-slack-notification.ts
@@ -1,6 +1,6 @@
 import { NonRetriableError } from 'inngest'
-import { isEmpty } from 'lodash'
 import pluralize from 'pluralize'
+import { isEmpty } from 'src/lib/utils/is-empty'
 
 import {
 	CoreInngestFunctionInput,

--- a/packages/core/src/lib/pricing/stripe-checkout.ts
+++ b/packages/core/src/lib/pricing/stripe-checkout.ts
@@ -1,6 +1,5 @@
 import { add } from 'date-fns'
 import first from 'lodash/first'
-import isEmpty from 'lodash/isEmpty'
 import { CourseBuilderAdapter } from 'src/adapters'
 import { CheckoutSessionMetadataSchema } from 'src/schemas/stripe/checkout-session-metadata'
 import Stripe from 'stripe'
@@ -8,6 +7,7 @@ import { z } from 'zod'
 
 import { Product, Purchase, UpgradableProduct } from '../../schemas'
 import { PaymentsAdapter, PaymentsProviderConsumerConfig } from '../../types'
+import { isEmpty } from '../utils/is-empty'
 import { getFixedDiscountForIndividualUpgrade } from './format-prices-for-product'
 import { getCalculatedPrice } from './get-calculated-price'
 

--- a/packages/core/src/lib/pricing/stripe-purchase-utils.ts
+++ b/packages/core/src/lib/pricing/stripe-purchase-utils.ts
@@ -1,4 +1,4 @@
-import { first, isEmpty, sortBy } from 'lodash'
+import { first } from 'lodash'
 import { CourseBuilderAdapter } from 'src/adapters'
 import { Purchase } from 'src/schemas'
 import {
@@ -14,6 +14,9 @@ import {
 	PurchaseType,
 } from 'src/schemas/purchase-type'
 import Stripe from 'stripe'
+
+import { isEmpty } from '../utils/is-empty'
+import { sortBy } from '../utils/sort-by'
 
 export async function parsePurchaseInfoFromCheckoutSession(
 	checkoutSession: Stripe.Checkout.Session,

--- a/packages/core/src/lib/send-verification-request.ts
+++ b/packages/core/src/lib/send-verification-request.ts
@@ -1,7 +1,5 @@
-import process from 'process'
 import { Theme } from '@auth/core/types'
 import { render } from '@react-email/components'
-import { createTransport } from 'nodemailer'
 
 import { NewMemberEmail } from '@coursebuilder/email-templates/emails/new-member'
 import { PostPurchaseLoginEmail } from '@coursebuilder/email-templates/emails/post-purchase-login'

--- a/packages/core/src/lib/utils/is-empty.ts
+++ b/packages/core/src/lib/utils/is-empty.ts
@@ -1,0 +1,19 @@
+/**
+ * Type guard for empty values (null, undefined, empty arrays, empty objects, empty strings)
+ */
+export function isEmpty(value: unknown): boolean {
+	if (value == null) return true
+	if (typeof value === 'string') return value.trim().length === 0
+	if (Array.isArray(value)) return value.length === 0
+	if (value instanceof Map || value instanceof Set) return value.size === 0
+	if (typeof value === 'object') return Object.keys(value).length === 0
+
+	return false
+}
+
+/**
+ * Type guard for non-empty values
+ */
+export function isNotEmpty<T>(value: T | null | undefined): value is T {
+	return !isEmpty(value)
+}

--- a/packages/core/src/lib/utils/sort-by.ts
+++ b/packages/core/src/lib/utils/sort-by.ts
@@ -1,0 +1,20 @@
+type PropertyPath = string | number | symbol
+type SortByIteratee<T> = ((obj: T) => any) | PropertyPath
+
+/**
+ * Sorts an array by a property path or iteratee function
+ */
+export function sortBy<T>(array: T[], iteratee: SortByIteratee<T>): T[] {
+	const cb =
+		typeof iteratee === 'function' ? iteratee : (obj: any) => obj[iteratee]
+
+	return [...array].sort((a, b) => {
+		const valA = cb(a)
+		const valB = cb(b)
+
+		if (valA === valB) return 0
+		if (valA == null) return 1
+		if (valB == null) return -1
+		return valA < valB ? -1 : 1
+	})
+}

--- a/packages/core/src/providers/convertkit.ts
+++ b/packages/core/src/providers/convertkit.ts
@@ -1,4 +1,5 @@
-import { find, isEmpty } from 'lodash'
+import { find } from 'lodash'
+import { isEmpty } from 'src/lib/utils/is-empty'
 import { z } from 'zod'
 
 import { Cookie } from '../lib/utils/cookie'

--- a/packages/core/src/providers/slack.ts
+++ b/packages/core/src/providers/slack.ts
@@ -19,6 +19,7 @@ export interface MessageAttachment {
 	author_name?: string
 	author_link?: string
 	author_icon?: string
+	mrkdwn_in?: string[]
 	title?: string
 	title_link?: string
 	text?: string

--- a/packages/core/src/providers/slack.ts
+++ b/packages/core/src/providers/slack.ts
@@ -1,8 +1,38 @@
-import {
-	ChatPostMessageResponse,
-	MessageAttachment,
-	WebClient,
-} from '@slack/web-api'
+export interface ChatPostMessageResponse {
+	ok: boolean
+	channel: string
+	ts: string
+	message: {
+		text: string
+		username: string
+		bot_id?: string
+		attachments?: MessageAttachment[]
+		type: string
+		subtype?: string
+	}
+}
+
+export interface MessageAttachment {
+	fallback?: string
+	color?: string
+	pretext?: string
+	author_name?: string
+	author_link?: string
+	author_icon?: string
+	title?: string
+	title_link?: string
+	text?: string
+	fields?: {
+		title: string
+		value: string
+		short?: boolean
+	}[]
+	image_url?: string
+	thumb_url?: string
+	footer?: string
+	footer_icon?: string
+	ts?: number
+}
 
 export interface NotificationProviderConfig {
 	id: string
@@ -45,7 +75,6 @@ export default function SlackProvider(
 			if (!options.apiKey) {
 				throw new Error('No apiKey found for notification provider')
 			}
-			const webClient = new WebClient(options.apiKey)
 			const channel = sendOptions.channel || options.defaultChannelId
 			if (!channel) {
 				throw new Error('No channel found')
@@ -56,14 +85,28 @@ export default function SlackProvider(
 				icon_emoji = ':robot_face:',
 				username = 'Announce Bot',
 			} = sendOptions
+
 			try {
-				return await webClient.chat.postMessage({
-					icon_emoji,
-					username,
-					attachments,
-					channel,
-					text,
+				const response = await fetch('https://slack.com/api/chat.postMessage', {
+					method: 'POST',
+					headers: {
+						Authorization: `Bearer ${options.apiKey}`,
+						'Content-Type': 'application/json',
+					},
+					body: JSON.stringify({
+						icon_emoji,
+						username,
+						attachments,
+						channel,
+						text,
+					}),
 				})
+
+				if (!response.ok) {
+					throw new Error(`Slack API error: ${response.statusText}`)
+				}
+
+				return (await response.json()) as ChatPostMessageResponse
 			} catch (e) {
 				console.log(e)
 				return Promise.reject(e)

--- a/packages/core/src/schemas/organization-member.ts
+++ b/packages/core/src/schemas/organization-member.ts
@@ -1,5 +1,8 @@
 import { z } from 'zod'
 
+import { OrganizationSchema } from './organization-schema'
+import { userSchema } from './user-schema'
+
 export const OrganizationMemberSchema = z.object({
 	id: z.string(),
 	organizationId: z.string().optional(),
@@ -8,6 +11,8 @@ export const OrganizationMemberSchema = z.object({
 	userId: z.string(),
 	fields: z.record(z.any()).default({}),
 	createdAt: z.date().default(() => new Date()),
+	organization: OrganizationSchema,
+	user: userSchema,
 })
 
 export type OrganizationMember = z.infer<typeof OrganizationMemberSchema>

--- a/packages/core/src/schemas/subscription.ts
+++ b/packages/core/src/schemas/subscription.ts
@@ -9,7 +9,18 @@ export const SubscriptionSchema = z.object({
 	productId: z.string(),
 	createdAt: z.date(),
 	merchantSubscriptionId: z.string(),
-	status: z.string().default('active'),
+	status: z
+		.enum([
+			'incomplete',
+			'incomplete_expired',
+			'trialing',
+			'active',
+			'past_due',
+			'canceled',
+			'unpaid',
+			'paused',
+		])
+		.default('active'),
 	fields: z.record(z.any()).default({}),
 	product: productSchema,
 	merchantSubscription: MerchantSubscriptionSchema.optional(),

--- a/packages/core/src/schemas/user-schema.ts
+++ b/packages/core/src/schemas/user-schema.ts
@@ -28,6 +28,18 @@ export const userSchema = z.object({
 		)
 		.optional()
 		.default([]),
+	organizationRoles: z
+		.array(
+			z.object({
+				id: z.string(),
+				organizationId: z.string(),
+				name: z.string(),
+				description: z.string().nullable(),
+				active: z.boolean(),
+			}),
+		)
+		.optional()
+		.default([]),
 })
 
 export type User = z.infer<typeof userSchema>

--- a/packages/core/test/is-empty.test.ts
+++ b/packages/core/test/is-empty.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, test } from 'vitest'
+
+import { isEmpty, isNotEmpty } from '../src/lib/utils/is-empty'
+
+describe('isEmpty', () => {
+	test('handles null/undefined', () => {
+		expect(isEmpty(null)).toBe(true)
+		expect(isEmpty(undefined)).toBe(true)
+	})
+
+	test('handles strings', () => {
+		expect(isEmpty('')).toBe(true)
+		expect(isEmpty('   ')).toBe(true)
+		expect(isEmpty('hello')).toBe(false)
+		expect(isEmpty(' hi ')).toBe(false)
+	})
+
+	test('handles arrays', () => {
+		expect(isEmpty([])).toBe(true)
+		expect(isEmpty([1, 2, 3])).toBe(false)
+		expect(isEmpty([null])).toBe(false)
+	})
+
+	test('handles objects', () => {
+		expect(isEmpty({})).toBe(true)
+		expect(isEmpty({ a: 1 })).toBe(false)
+		expect(isEmpty({ length: 0 })).toBe(false)
+	})
+
+	test('handles Map/Set', () => {
+		expect(isEmpty(new Map())).toBe(true)
+		expect(isEmpty(new Set())).toBe(true)
+		expect(isEmpty(new Map([['a', 1]]))).toBe(false)
+		expect(isEmpty(new Set([1]))).toBe(false)
+	})
+
+	test('handles other types', () => {
+		expect(isEmpty(0)).toBe(false)
+		expect(isEmpty(false)).toBe(false)
+		expect(isEmpty(true)).toBe(false)
+	})
+})
+
+describe('isNotEmpty', () => {
+	test('type guard works', () => {
+		const value: string | null = 'hello'
+		if (isNotEmpty(value)) {
+			expect(value.length).toBeGreaterThan(0)
+		}
+	})
+})

--- a/packages/core/test/sort-by.test.ts
+++ b/packages/core/test/sort-by.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, test } from 'vitest'
+
+import { sortBy } from '../src/lib/utils/sort-by'
+
+describe('sortBy', () => {
+	const users = [
+		{ id: 1, name: 'Bob', age: 30 },
+		{ id: 2, name: 'Alice', age: 25 },
+		{ id: 3, name: 'Charlie', age: null },
+		{ id: 4, name: 'David', age: undefined },
+	]
+
+	test('sorts by property path', () => {
+		const sorted = sortBy(users, 'name')
+		expect(sorted.map((u) => u.name)).toEqual([
+			'Alice',
+			'Bob',
+			'Charlie',
+			'David',
+		])
+	})
+
+	test('sorts by iteratee function', () => {
+		const sorted = sortBy(users, (u) => u.age)
+		expect(sorted.map((u) => u.id)).toEqual([2, 1, 3, 4])
+	})
+
+	test('handles null/undefined values', () => {
+		const items = [null, 3, 1, undefined, 2]
+		const sorted = sortBy(items, (x) => x)
+		expect(sorted).toEqual([1, 2, 3, null, undefined])
+	})
+
+	test('preserves original array', () => {
+		const original = [3, 1, 2]
+		const sorted = sortBy(original, (x) => x)
+		expect(sorted).toEqual([1, 2, 3])
+		expect(original).toEqual([3, 1, 2])
+	})
+
+	test('handles empty arrays', () => {
+		expect(sortBy([], 'whatever')).toEqual([])
+	})
+
+	test('maintains stability for equal values', () => {
+		const items = [
+			{ group: 'A', val: 1 },
+			{ group: 'A', val: 2 },
+			{ group: 'B', val: 3 },
+		]
+		const sorted = sortBy(items, 'group')
+		expect(sorted[0].val).toBe(1)
+		expect(sorted[1].val).toBe(2)
+	})
+})

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -24,7 +24,11 @@
 		"outDir": ".",
 		"rootDir": "src"
 	},
-	"include": [".eslintrc.cjs", "src/**/*"],
+	"include": [
+		".eslintrc.cjs",
+		"src/**/*",
+		"../../apps/ai-hero/src/subscriptions/stripe-subscription-utils.ts"
+	],
 	"exclude": [
 		"node_modules",
 		"*.js",

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -24,11 +24,7 @@
 		"outDir": ".",
 		"rootDir": "src"
 	},
-	"include": [
-		".eslintrc.cjs",
-		"src/**/*",
-		"../../apps/ai-hero/src/subscriptions/stripe-subscription-utils.ts"
-	],
+	"include": [".eslintrc.cjs", "src/**/*"],
 	"exclude": [
 		"node_modules",
 		"*.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -242,6 +242,9 @@ importers:
       '@planetscale/database':
         specifier: 1.19.0
         version: 1.19.0
+      '@playwright/test':
+        specifier: ^1.46.1
+        version: 1.49.1
       '@react-email/components':
         specifier: 0.0.27
         version: 0.0.27(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
@@ -356,6 +359,9 @@ importers:
       date-fns-tz:
         specifier: ^2.0.1
         version: 2.0.1(date-fns@2.30.0)
+      dotenv:
+        specifier: ^10.0.0
+        version: 10.0.0
       dotenv-flow:
         specifier: ^4.1.0
         version: 4.1.0
@@ -415,7 +421,7 @@ importers:
         version: 5.0.6
       next:
         specifier: 15.0.3
-        version: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
+        version: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
       next-auth:
         specifier: 5.0.0-beta.25
         version: 5.0.0-beta.25(next@15.0.3)(nodemailer@6.9.11)(react@19.0.0-rc-02c0e824-20241028)
@@ -1016,7 +1022,7 @@ importers:
         version: 5.0.6
       next:
         specifier: 15.0.3
-        version: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
+        version: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
       next-auth:
         specifier: 5.0.0-beta.25
         version: 5.0.0-beta.25(next@15.0.3)(nodemailer@6.9.11)(react@19.0.0-rc-02c0e824-20241028)
@@ -1422,7 +1428,7 @@ importers:
         version: 5.0.6
       next:
         specifier: 15.0.3
-        version: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
+        version: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
       next-auth:
         specifier: 5.0.0-beta.25
         version: 5.0.0-beta.25(next@15.0.3)(nodemailer@6.9.11)(react@19.0.0-rc-02c0e824-20241028)
@@ -1864,7 +1870,7 @@ importers:
         version: 5.0.6
       next:
         specifier: 15.0.3
-        version: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
+        version: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
       next-auth:
         specifier: 5.0.0-beta.25
         version: 5.0.0-beta.25(next@15.0.3)(nodemailer@6.9.11)(react@19.0.0-rc-02c0e824-20241028)
@@ -2279,7 +2285,7 @@ importers:
         version: 5.0.6
       next:
         specifier: 15.0.3
-        version: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
+        version: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
       next-auth:
         specifier: 5.0.0-beta.25
         version: 5.0.0-beta.25(next@15.0.3)(nodemailer@6.9.11)(react@19.0.0-rc-02c0e824-20241028)
@@ -2586,7 +2592,7 @@ importers:
         version: 5.0.6
       next:
         specifier: 15.0.3
-        version: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
+        version: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
       next-auth:
         specifier: 5.0.0-beta.25
         version: 5.0.0-beta.25(next@15.0.3)(nodemailer@6.9.11)(react@19.0.0-rc-02c0e824-20241028)
@@ -3064,7 +3070,7 @@ importers:
         version: 5.0.6
       next:
         specifier: 15.0.3
-        version: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
+        version: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
       next-auth:
         specifier: 5.0.0-beta.25
         version: 5.0.0-beta.25(next@15.0.3)(nodemailer@6.9.11)(react@19.0.0-rc-02c0e824-20241028)
@@ -3713,7 +3719,7 @@ importers:
         version: 5.0.6
       next:
         specifier: 15.0.3
-        version: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
+        version: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
       next-auth:
         specifier: 5.0.0-beta.25
         version: 5.0.0-beta.25(next@15.0.3)(nodemailer@6.9.11)(react@19.0.0-rc-02c0e824-20241028)
@@ -4323,7 +4329,7 @@ importers:
         version: 5.0.6
       next:
         specifier: 15.0.3
-        version: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
+        version: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
       next-auth:
         specifier: 5.0.0-beta.25
         version: 5.0.0-beta.25(next@15.0.3)(nodemailer@6.9.11)(react@19.0.0-rc-02c0e824-20241028)
@@ -4951,7 +4957,7 @@ importers:
         version: 5.0.6
       next:
         specifier: 15.0.3
-        version: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
+        version: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
       next-auth:
         specifier: 5.0.0-beta.25
         version: 5.0.0-beta.25(next@15.0.3)(nodemailer@6.9.11)(react@19.0.0-rc-02c0e824-20241028)
@@ -5540,7 +5546,7 @@ importers:
         version: 5.0.6
       next:
         specifier: 15.0.3
-        version: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
+        version: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
       next-auth:
         specifier: 5.0.0-beta.25
         version: 5.0.0-beta.25(next@15.0.3)(nodemailer@6.9.11)(react@19.0.0-rc-02c0e824-20241028)
@@ -12233,7 +12239,7 @@ packages:
       next: ^13.0.0 || ^14.0.0 || ^15.0.0
       react: ^18.2.0 || 19.0.0-rc-02c0e824-20241028
     dependencies:
-      next: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
+      next: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
       react: 19.0.0-rc-02c0e824-20241028
       third-party-capital: 1.0.20
     dev: false
@@ -12728,6 +12734,13 @@ packages:
   /@planetscale/database@1.19.0:
     resolution: {integrity: sha512-Tv4jcFUFAFjOWrGSio49H6R2ijALv0ZzVBfJKIdm+kl9X046Fh4LLawrF9OMsglVbK6ukqMJsUCeucGAFTBcMA==}
     engines: {node: '>=16'}
+
+  /@playwright/test@1.49.1:
+    resolution: {integrity: sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==}
+    engines: {node: '>=18'}
+    hasBin: true
+    dependencies:
+      playwright: 1.49.1
 
   /@pnpm/config.env-replace@1.1.0:
     resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
@@ -17498,7 +17511,7 @@ packages:
       '@sentry/vercel-edge': 8.26.0
       '@sentry/webpack-plugin': 2.20.1(encoding@0.1.13)(webpack@5.97.1)
       chalk: 3.0.0
-      next: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
+      next: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
       resolve: 1.22.8
       rollup: 3.29.4
       stacktrace-parser: 0.1.10
@@ -17738,7 +17751,7 @@ packages:
       react: ^17.0.2 < 18.0.0
     dependencies:
       lodash: 4.17.21
-      next: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
+      next: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
       react: 19.0.0-rc-02c0e824-20241028
     dev: false
 
@@ -19085,7 +19098,7 @@ packages:
       '@trpc/client': 11.0.0-rc.351(@trpc/server@11.0.0-rc.351)
       '@trpc/react-query': 11.0.0-rc.351(@tanstack/react-query@5.54.1)(@trpc/client@11.0.0-rc.351)(@trpc/server@11.0.0-rc.351)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
       '@trpc/server': 11.0.0-rc.351
-      next: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
+      next: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
       react: 19.0.0-rc-02c0e824-20241028
       react-dom: 19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028)
 
@@ -19109,7 +19122,7 @@ packages:
       '@trpc/client': 11.0.0-rc.366(@trpc/server@11.0.0-rc.366)
       '@trpc/react-query': 11.0.0-rc.366(@tanstack/react-query@5.54.1)(@trpc/client@11.0.0-rc.366)(@trpc/server@11.0.0-rc.366)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
       '@trpc/server': 11.0.0-rc.366
-      next: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
+      next: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
       react: 19.0.0-rc-02c0e824-20241028
       react-dom: 19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028)
     dev: false
@@ -19134,7 +19147,7 @@ packages:
       '@trpc/client': 11.0.0-rc.377(@trpc/server@11.0.0-rc.377)
       '@trpc/react-query': 11.0.0-rc.377(@tanstack/react-query@5.54.1)(@trpc/client@11.0.0-rc.377)(@trpc/server@11.0.0-rc.377)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
       '@trpc/server': 11.0.0-rc.377
-      next: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
+      next: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
       react: 19.0.0-rc-02c0e824-20241028
       react-dom: 19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028)
     dev: false
@@ -19159,7 +19172,7 @@ packages:
       '@trpc/client': 11.0.0-rc.390(@trpc/server@11.0.0-rc.390)
       '@trpc/react-query': 11.0.0-rc.390(@tanstack/react-query@5.54.1)(@trpc/client@11.0.0-rc.390)(@trpc/server@11.0.0-rc.390)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
       '@trpc/server': 11.0.0-rc.390
-      next: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
+      next: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
       react: 19.0.0-rc-02c0e824-20241028
       react-dom: 19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028)
     dev: false
@@ -19184,7 +19197,7 @@ packages:
       '@trpc/client': 11.0.0-rc.477(@trpc/server@11.0.0-rc.477)
       '@trpc/react-query': 11.0.0-rc.477(@tanstack/react-query@5.54.1)(@trpc/client@11.0.0-rc.477)(@trpc/server@11.0.0-rc.477)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
       '@trpc/server': 11.0.0-rc.477
-      next: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
+      next: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
       react: 19.0.0-rc-02c0e824-20241028
       react-dom: 19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028)
     dev: false
@@ -19209,7 +19222,7 @@ packages:
       '@trpc/client': 11.0.0-rc.604(@trpc/server@11.0.0-rc.604)
       '@trpc/react-query': 11.0.0-rc.604(@tanstack/react-query@5.54.1)(@trpc/client@11.0.0-rc.604)(@trpc/server@11.0.0-rc.604)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
       '@trpc/server': 11.0.0-rc.604
-      next: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
+      next: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
       react: 19.0.0-rc-02c0e824-20241028
       react-dom: 19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028)
     dev: false
@@ -19234,7 +19247,7 @@ packages:
       '@trpc/client': 11.0.0-rc.621(@trpc/server@11.0.0-rc.621)
       '@trpc/react-query': 11.0.0-rc.621(@tanstack/react-query@5.54.1)(@trpc/client@11.0.0-rc.621)(@trpc/server@11.0.0-rc.621)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
       '@trpc/server': 11.0.0-rc.621
-      next: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
+      next: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
       react: 19.0.0-rc-02c0e824-20241028
       react-dom: 19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028)
     dev: false
@@ -20666,7 +20679,7 @@ packages:
       '@uploadthing/dropzone': 0.4.1(react@19.0.0-rc-02c0e824-20241028)(solid-js@1.9.3)(svelte@4.2.19)(vue@3.5.13)
       '@uploadthing/shared': 6.7.8
       file-selector: 0.6.0
-      next: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
+      next: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
       react: 19.0.0-rc-02c0e824-20241028
       tailwind-merge: 2.4.0
       uploadthing: 6.13.2(next@15.0.3)(tailwindcss@3.4.1)
@@ -23725,7 +23738,6 @@ packages:
   /dotenv@10.0.0:
     resolution: {integrity: sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==}
     engines: {node: '>=10'}
-    dev: true
 
   /dotenv@16.0.3:
     resolution: {integrity: sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==}
@@ -26192,6 +26204,13 @@ packages:
   /fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  /fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+    requiresBuild: true
+    optional: true
+
   /fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -26219,7 +26238,7 @@ packages:
     peerDependencies:
       next: '>=13.2.0 <15.0.0-0'
     dependencies:
-      next: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
+      next: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
     dev: false
 
   /generate-function@2.3.1:
@@ -27357,7 +27376,7 @@ packages:
       hash.js: 1.1.7
       json-stringify-safe: 5.0.1
       ms: 2.1.3
-      next: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
+      next: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
       serialize-error-cjs: 0.1.3
       strip-ansi: 5.2.0
       typescript: 5.4.5
@@ -27411,7 +27430,7 @@ packages:
       hash.js: 1.1.7
       json-stringify-safe: 5.0.1
       ms: 2.1.3
-      next: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
+      next: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
       serialize-error-cjs: 0.1.3
       strip-ansi: 5.2.0
       typescript: 5.4.5
@@ -31064,7 +31083,7 @@ packages:
         optional: true
     dependencies:
       '@auth/core': 0.37.2(nodemailer@6.9.11)
-      next: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
+      next: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
       nodemailer: 6.9.11
       react: 19.0.0-rc-02c0e824-20241028
     dev: false
@@ -31096,7 +31115,7 @@ packages:
       next: '>=13.4'
       react: '>=18.0.0'
     dependencies:
-      next: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
+      next: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
       react: 19.0.0-rc-02c0e824-20241028
       remeda: 1.50.1
       whatwg-fetch: 3.6.20
@@ -31112,7 +31131,7 @@ packages:
       '@cloudinary-util/url-loader': 5.2.2
       '@cloudinary-util/util': 3.0.0
       '@tsconfig/recommended': 1.0.6
-      next: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
+      next: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
       react: 19.0.0-rc-02c0e824-20241028
     dev: false
 
@@ -31273,7 +31292,7 @@ packages:
       - babel-plugin-macros
     dev: true
 
-  /next@15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028):
+  /next@15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028):
     resolution: {integrity: sha512-ontCbCRKJUIoivAdGB34yCaOcPgYXr9AAkV/IwqFfWWTXEPUgLYkSkqBhIk9KK7gGmgjc64B+RdoeIDM13Irnw==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
     hasBin: true
@@ -31296,6 +31315,7 @@ packages:
     dependencies:
       '@next/env': 15.0.3
       '@opentelemetry/api': 1.9.0
+      '@playwright/test': 1.49.1
       '@swc/counter': 0.1.3
       '@swc/helpers': 0.5.13
       busboy: 1.6.0
@@ -31606,7 +31626,7 @@ packages:
         optional: true
     dependencies:
       mitt: 3.0.1
-      next: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
+      next: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
       react: 19.0.0-rc-02c0e824-20241028
     dev: false
 
@@ -32405,6 +32425,20 @@ packages:
       mlly: 1.7.2
       pathe: 1.1.2
     dev: false
+
+  /playwright-core@1.49.1:
+    resolution: {integrity: sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  /playwright@1.49.1:
+    resolution: {integrity: sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==}
+    engines: {node: '>=18'}
+    hasBin: true
+    dependencies:
+      playwright-core: 1.49.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   /plop@4.0.1:
     resolution: {integrity: sha512-5n8QU93kvL/ObOzBcPAB1siVFtAH1TZM6TntJ3JK5kXT0jIgnQV+j+uaOWWFJlg1cNkzLYm8klgASF65K36q9w==}
@@ -33445,7 +33479,7 @@ packages:
       next: '>= 13.4 < 15'
       react-instantsearch: '>= 7.1.0 < 8'
     dependencies:
-      next: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
+      next: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
       react-instantsearch: 7.13.9(algoliasearch@5.17.1)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
     dev: false
 
@@ -33455,7 +33489,7 @@ packages:
       next: '>= 9 && < 15'
     dependencies:
       instantsearch.js: 4.75.6(algoliasearch@5.17.1)
-      next: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
+      next: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
       react-instantsearch-core: 7.13.9(algoliasearch@5.17.1)(react@19.0.0-rc-02c0e824-20241028)
     transitivePeerDependencies:
       - algoliasearch
@@ -37077,7 +37111,7 @@ packages:
       '@uploadthing/shared': 6.7.8
       consola: 3.2.3
       effect: 3.4.5
-      next: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
+      next: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
       std-env: 3.7.0
       tailwindcss: 3.4.1(ts-node@10.9.2)
     dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -359,9 +359,6 @@ importers:
       date-fns-tz:
         specifier: ^2.0.1
         version: 2.0.1(date-fns@2.30.0)
-      dotenv:
-        specifier: ^10.0.0
-        version: 10.0.0
       dotenv-flow:
         specifier: ^4.1.0
         version: 4.1.0
@@ -23738,6 +23735,7 @@ packages:
   /dotenv@10.0.0:
     resolution: {integrity: sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==}
     engines: {node: '>=10'}
+    dev: true
 
   /dotenv@16.0.3:
     resolution: {integrity: sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -633,9 +633,6 @@ importers:
       concurrently:
         specifier: ^8.2.2
         version: 8.2.2
-      dotenv-cli:
-        specifier: ^7.4.1
-        version: 7.4.1
       drizzle-kit:
         specifier: 0.27.1
         version: 0.27.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -628,7 +628,7 @@ importers:
         specifier: ^8.2.2
         version: 8.2.2
       dotenv-cli:
-        specifier: ^7.3.0
+        specifier: ^7.4.1
         version: 7.4.1
       drizzle-kit:
         specifier: 0.27.1
@@ -675,6 +675,9 @@ importers:
       typescript:
         specifier: 5.4.5
         version: 5.4.5
+      vite-tsconfig-paths:
+        specifier: ^5.1.4
+        version: 5.1.4(typescript@5.4.5)(vite@5.4.10)
 
   apps/astro-party:
     dependencies:
@@ -6977,7 +6980,7 @@ packages:
     engines: {node: '>=18.14.1'}
     dependencies:
       ci-info: 3.9.0
-      debug: 4.3.7
+      debug: 4.4.0(supports-color@5.5.0)
       dlv: 1.1.3
       dset: 3.1.3
       is-docker: 3.0.0
@@ -8264,7 +8267,7 @@ packages:
       '@babel/traverse': 7.24.0
       '@babel/types': 7.24.0
       convert-source-map: 2.0.0
-      debug: 4.3.4
+      debug: 4.4.0(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -8286,7 +8289,7 @@ packages:
       '@babel/traverse': 7.25.9
       '@babel/types': 7.26.0
       convert-source-map: 2.0.0
-      debug: 4.3.7
+      debug: 4.4.0(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -8309,7 +8312,7 @@ packages:
       '@babel/traverse': 7.26.4
       '@babel/types': 7.26.3
       convert-source-map: 2.0.0
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -8882,7 +8885,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/parser': 7.24.0
       '@babel/types': 7.26.0
-      debug: 4.3.7
+      debug: 4.4.0(supports-color@5.5.0)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -8899,7 +8902,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.24.7
       '@babel/parser': 7.24.8
       '@babel/types': 7.24.9
-      debug: 4.3.5(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@5.5.0)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -8914,7 +8917,7 @@ packages:
       '@babel/parser': 7.26.2
       '@babel/template': 7.25.9
       '@babel/types': 7.26.0
-      debug: 4.3.7
+      debug: 4.4.0(supports-color@5.5.0)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -8928,7 +8931,7 @@ packages:
       '@babel/parser': 7.26.3
       '@babel/template': 7.25.9
       '@babel/types': 7.26.3
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -10852,7 +10855,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.5(supports-color@5.5.0)
+      debug: 4.3.5
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.1
@@ -11041,7 +11044,7 @@ packages:
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 2.0.2
-      debug: 4.3.5(supports-color@5.5.0)
+      debug: 4.3.5
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -11052,7 +11055,7 @@ packages:
     deprecated: Use @eslint/config-array instead
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.3.7
+      debug: 4.4.0(supports-color@5.5.0)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -20327,7 +20330,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.4.5)
       '@typescript-eslint/utils': 6.21.0(eslint@8.57.0)(typescript@5.4.5)
-      debug: 4.3.4
+      debug: 4.4.0(supports-color@5.5.0)
       eslint: 8.57.0
       ts-api-utils: 1.3.0(typescript@5.4.5)
       typescript: 5.4.5
@@ -20346,7 +20349,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.4.5)
       '@typescript-eslint/utils': 6.21.0(eslint@8.57.1)(typescript@5.4.5)
-      debug: 4.3.4
+      debug: 4.4.0(supports-color@5.5.0)
       eslint: 8.57.1
       ts-api-utils: 1.3.0(typescript@5.4.5)
       typescript: 5.4.5
@@ -20369,7 +20372,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.3.5(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@5.5.0)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
@@ -21271,7 +21274,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.7
+      debug: 4.4.0(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -22487,7 +22490,7 @@ packages:
   /capnp-ts@0.7.0:
     resolution: {integrity: sha512-XKxXAC3HVPv7r674zP0VC3RTXz+/JKhfyw94ljvF80yynK6VkTnqE3jMuN8b3dUVmmc43TjyxjW4KTsmB3c86g==}
     dependencies:
-      debug: 4.3.7
+      debug: 4.4.0(supports-color@5.5.0)
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -23328,7 +23331,7 @@ packages:
     dependencies:
       ms: 2.1.2
 
-  /debug@4.3.5(supports-color@5.5.0):
+  /debug@4.3.5:
     resolution: {integrity: sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==}
     engines: {node: '>=6.0'}
     peerDependencies:
@@ -23338,7 +23341,6 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
-      supports-color: 5.5.0
 
   /debug@4.3.7:
     resolution: {integrity: sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==}
@@ -23351,7 +23353,7 @@ packages:
     dependencies:
       ms: 2.1.3
 
-  /debug@4.4.0:
+  /debug@4.4.0(supports-color@5.5.0):
     resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
     engines: {node: '>=6.0'}
     peerDependencies:
@@ -23361,6 +23363,7 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.3
+      supports-color: 5.5.0
 
   /decamelize-keys@1.1.1:
     resolution: {integrity: sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==}
@@ -26470,6 +26473,10 @@ packages:
       slash: 4.0.0
     dev: false
 
+  /globrex@0.1.2:
+    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
+    dev: true
+
   /goober@2.1.14(csstype@3.1.3):
     resolution: {integrity: sha512-4UpC0NdGyAFqLNPnhCT2iHpza2q+RAY3GV85a/mRPdzyPQMsj0KmMMuetdIkzWRbJ+Hgau1EZztq8ImmiMGhsg==}
     peerDependencies:
@@ -27138,7 +27145,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.7
+      debug: 4.4.0(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -27346,7 +27353,7 @@ packages:
       canonicalize: 1.0.8
       chalk: 4.1.2
       cross-fetch: 4.0.0(encoding@0.1.13)
-      debug: 4.3.5(supports-color@5.5.0)
+      debug: 4.3.5
       hash.js: 1.1.7
       json-stringify-safe: 5.0.1
       ms: 2.1.3
@@ -27400,7 +27407,7 @@ packages:
       canonicalize: 1.0.8
       chalk: 4.1.2
       cross-fetch: 4.0.0(encoding@0.1.13)
-      debug: 4.3.5(supports-color@5.5.0)
+      debug: 4.3.5
       hash.js: 1.1.7
       json-stringify-safe: 5.0.1
       ms: 2.1.3
@@ -27957,7 +27964,7 @@ packages:
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
     dependencies:
-      debug: 4.3.4
+      debug: 4.4.0(supports-color@5.5.0)
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -30295,7 +30302,7 @@ packages:
     resolution: {integrity: sha512-uD66tJj54JLYq0De10AhWycZWGQNUvDI55xPgk2sQM5kn1JYlhbCMTtEeT27+vAhW2FBQxLlOmS3pmA7/2z4aA==}
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.3.7
+      debug: 4.4.0(supports-color@5.5.0)
       decode-named-character-reference: 1.0.2
       micromark-core-commonmark: 1.1.0
       micromark-factory-space: 1.1.0
@@ -30319,7 +30326,7 @@ packages:
     resolution: {integrity: sha512-o/sd0nMof8kYff+TqcDx3VSrgBTcZpSvYcAHIfHhv5VAuNmisCxjhx6YmxS8PFEpb9z5WKWKPdzf0jM23ro3RQ==}
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.3.7
+      debug: 4.4.0(supports-color@5.5.0)
       decode-named-character-reference: 1.0.2
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.0
@@ -34266,7 +34273,7 @@ packages:
     resolution: {integrity: sha512-X34iHADNbNDfr6OTStIAHWSAvvKQRYgLO6duASaVf7J2VA3lvmNYboAHOuLC2huav1IwgZJtyEcJCKVzFxOSMQ==}
     engines: {node: '>=8.6.0'}
     dependencies:
-      debug: 4.3.7
+      debug: 4.4.0(supports-color@5.5.0)
       module-details-from-path: 1.0.3
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -35297,7 +35304,7 @@ packages:
     resolution: {integrity: sha512-cw0jVGdNMAdC+7YpISD7qSFJTWSdnkuPHnBZ8v0hgIOef2OoB2l7lWZCiHOhI+ZzWgJ0bvwsjjSX81iMtCTOAQ==}
     dependencies:
       '@types/pg': 7.14.11
-      debug: 4.3.5(supports-color@5.5.0)
+      debug: 4.3.5
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -36343,7 +36350,6 @@ packages:
         optional: true
     dependencies:
       typescript: 5.4.5
-    dev: false
 
   /tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
@@ -37353,7 +37359,7 @@ packages:
     hasBin: true
     dependencies:
       cac: 6.7.14
-      debug: 4.3.7
+      debug: 4.4.0(supports-color@5.5.0)
       pathe: 1.1.2
       picocolors: 1.1.1
       vite: 5.4.10(@types/node@20.12.5)
@@ -37368,6 +37374,23 @@ packages:
       - supports-color
       - terser
     dev: false
+
+  /vite-tsconfig-paths@5.1.4(typescript@5.4.5)(vite@5.4.10):
+    resolution: {integrity: sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==}
+    peerDependencies:
+      vite: '*'
+    peerDependenciesMeta:
+      vite:
+        optional: true
+    dependencies:
+      debug: 4.4.0(supports-color@5.5.0)
+      globrex: 0.1.2
+      tsconfck: 3.0.3(typescript@5.4.5)
+      vite: 5.4.10(@types/node@20.12.5)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
 
   /vite@4.5.2(@types/node@20.12.5):
     resolution: {integrity: sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -633,6 +633,9 @@ importers:
       concurrently:
         specifier: ^8.2.2
         version: 8.2.2
+      dotenv-cli:
+        specifier: ^7.3.0
+        version: 7.4.1
       drizzle-kit:
         specifier: 0.27.1
         version: 0.27.1


### PR DESCRIPTION
extracted the inngest handler for subscription  checkout and moved it to ai-hero and 

added checkout session type filters to both for payments (unchanged) and subscriptions (only handled in ai hero for now)

updated abilities for org settings

added middleware for org cookies and headers since organizations are very pervasive across the whole app and you're in an "org context" that needs to be driven server side

using middleware has some tradeoffs since its edge runtime and dependencies will often not run. required making slim local versions of a couple loads h functions and using REST instead of sdk for slack 

UI for org list and billing settings (read only so far)

vitest setup in ai hero for some unit tests on utils and stuff

initial playwright config