### PR TITLE
feat(aih): adds posts api and oauth device flow

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
 	"typescript.tsdk": "node_modules/typescript/lib",
-	"cSpell.words": ["coursebuilder"]
+	"cSpell.words": [
+		"coursebuilder"
+	],
+	"vitest.disableWorkspaceWarning": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,5 @@
 {
 	"typescript.tsdk": "node_modules/typescript/lib",
-	"cSpell.words": [
-		"coursebuilder"
-	],
+	"cSpell.words": ["coursebuilder"],
 	"vitest.disableWorkspaceWarning": true
 }

--- a/apps/ai-hero/package.json
+++ b/apps/ai-hero/package.json
@@ -117,6 +117,7 @@
 		"framer-motion": "^12.0.0-alpha.1",
 		"groq": "^3.18.1",
 		"holy-loader": "^2.2.10",
+		"human-readable-ids": "^1.0.4",
 		"i": "^0.3.7",
 		"import-in-the-middle": "^1.11.2",
 		"inngest": "^3.22.5",

--- a/apps/ai-hero/package.json
+++ b/apps/ai-hero/package.json
@@ -159,6 +159,7 @@
 		"react-stately": "^3.33.0",
 		"react-use": "^17.5.0",
 		"react-wrap-balancer": "^0.2.4",
+		"reading-time": "^1.5.0",
 		"rehype-raw": "^7.0.0",
 		"rehype-slug": "^6.0.0",
 		"remark-gfm": "^4.0.0",

--- a/apps/ai-hero/src/@types/human-readable-ids.d.ts
+++ b/apps/ai-hero/src/@types/human-readable-ids.d.ts
@@ -1,0 +1,1 @@
+declare module 'human-readable-ids'

--- a/apps/ai-hero/src/ability/index.ts
+++ b/apps/ai-hero/src/ability/index.ts
@@ -61,29 +61,7 @@ export type AppAbility = MongoAbility<[Actions, Subjects]>
 export const createAppAbility = createMongoAbility as CreateAbility<AppAbility>
 
 type GetAbilityOptions = {
-	user?: {
-		id: string
-		role?: string
-		roles: {
-			id: string
-			name: string
-			description: string | null
-			active: boolean
-			createdAt: Date | null
-			updatedAt: Date | null
-			deletedAt: Date | null
-		}[]
-		organizationRoles?: {
-			organizationId: string | null
-			id: string
-			name: string
-			description: string | null
-			active: boolean
-			createdAt: Date | null
-			updatedAt: Date | null
-			deletedAt: Date | null
-		}[]
-	}
+	user?: User
 }
 
 /**

--- a/apps/ai-hero/src/app/(commerce)/products/[slug]/edit/_components/edit-product-form.tsx
+++ b/apps/ai-hero/src/app/(commerce)/products/[slug]/edit/_components/edit-product-form.tsx
@@ -149,7 +149,7 @@ export function EditProductForm({ product }: { product: Product }) {
 				image: {
 					url: product.fields.image?.url ?? '',
 				},
-				visibility: product.fields.visibility || 'unlisted',
+				visibility: product.fields.visibility || 'public',
 				state: product.fields.state || 'draft',
 			},
 		},

--- a/apps/ai-hero/src/app/(commerce)/subscribe/already-subscribed/page.tsx
+++ b/apps/ai-hero/src/app/(commerce)/subscribe/already-subscribed/page.tsx
@@ -16,6 +16,10 @@ import {
 export default async function AlreadySubscribedPage() {
 	const { session, ability } = await getServerAuthSession()
 
+	if (!session) {
+		return redirect('/')
+	}
+
 	const { user } = session
 
 	const { hasActiveSubscription } = await getSubscriptionStatus(user?.id)

--- a/apps/ai-hero/src/app/(content)/_components/edit-lesson-form.tsx
+++ b/apps/ai-hero/src/app/(content)/_components/edit-lesson-form.tsx
@@ -55,7 +55,7 @@ export function EditLessonForm({
 			fields: {
 				title: lesson.fields?.title || '',
 				body: lesson.fields?.body || '',
-				visibility: lesson.fields?.visibility || 'unlisted',
+				visibility: lesson.fields?.visibility || 'public',
 				state: lesson.fields?.state || 'draft',
 				description: lesson.fields?.description || '',
 				github: lesson.fields?.github || '',

--- a/apps/ai-hero/src/app/(content)/events/[slug]/edit/_components/edit-event-form.tsx
+++ b/apps/ai-hero/src/app/(content)/events/[slug]/edit/_components/edit-event-form.tsx
@@ -44,7 +44,7 @@ export function EditEventForm({ event }: { event: Event }) {
 					endsAt: new Date(event.fields.endsAt).toISOString(),
 				}),
 				title: event.fields.title || '',
-				visibility: event.fields.visibility || 'unlisted',
+				visibility: event.fields.visibility || 'public',
 				image: event.fields.image || '',
 				description: event.fields.description ?? '',
 				slug: event.fields.slug ?? '',

--- a/apps/ai-hero/src/app/(content)/posts/_components/create-post.tsx
+++ b/apps/ai-hero/src/app/(content)/posts/_components/create-post.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation'
 import { PostUploader } from '@/app/(content)/posts/_components/post-uploader'
+import { NewResourceWithVideoForm } from '@/components/resources-crud/new-resource-with-video-form'
 import { createPost } from '@/lib/posts-query'
 import { getVideoResource } from '@/lib/video-resource-query'
 import { FilePlus2 } from 'lucide-react'
@@ -15,7 +16,6 @@ import {
 	DialogHeader,
 	DialogTrigger,
 } from '@coursebuilder/ui'
-import { NewResourceWithVideoForm } from '@coursebuilder/ui/resources-crud/new-resource-with-video-form'
 
 export function CreatePost() {
 	const router = useRouter()

--- a/apps/ai-hero/src/app/(content)/posts/_components/edit-post-form.tsx
+++ b/apps/ai-hero/src/app/(content)/posts/_components/edit-post-form.tsx
@@ -55,7 +55,7 @@ export function EditPostForm({
 				title: post.fields?.title,
 				body: post.fields?.body,
 				slug: post.fields?.slug,
-				visibility: post.fields?.visibility || 'unlisted',
+				visibility: post.fields?.visibility || 'public',
 				state: post.fields?.state || 'draft',
 				description: post.fields?.description ?? '',
 				github: post.fields?.github ?? '',

--- a/apps/ai-hero/src/app/(content)/tutorials/_components/edit-tutorial-form.tsx
+++ b/apps/ai-hero/src/app/(content)/tutorials/_components/edit-tutorial-form.tsx
@@ -75,7 +75,7 @@ export function EditTutorialForm({ tutorial }: { tutorial: ContentResource }) {
 								.default('draft'),
 							visibility: z
 								.enum(['public', 'private', 'unlisted'])
-								.default('unlisted'),
+								.default('public'),
 							body: z.string().nullable().optional(),
 						}),
 					}),

--- a/apps/ai-hero/src/app/(user)/activate/_components/verifiy.tsx
+++ b/apps/ai-hero/src/app/(user)/activate/_components/verifiy.tsx
@@ -18,7 +18,7 @@ export default function Verify({ userCode }: { userCode: string }) {
 				<Fingerprint animate={animate} />
 				<h1 className="text-2xl font-bold sm:text-3xl">Device Confirmation</h1>
 				<p className="py-4 text-gray-600 dark:text-gray-400">
-					Please confirm this is the code displayed in your Workshop App
+					Please confirm this is the code displayed in your app
 				</p>
 				<div className="w-full rounded-md border px-5 py-3 text-lg font-semibold dark:border-transparent dark:bg-black/75">
 					{userCode}

--- a/apps/ai-hero/src/app/(user)/activate/_components/verifiy.tsx
+++ b/apps/ai-hero/src/app/(user)/activate/_components/verifiy.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import React from 'react'
+import { useRouter } from 'next/navigation'
+import { api } from '@/trpc/react'
+import { motion } from 'framer-motion'
+
+import { Button } from '@coursebuilder/ui'
+import { cn } from '@coursebuilder/ui/utils/cn'
+
+export default function Verify({ userCode }: { userCode: string }) {
+	const verifyDeviceMutation = api.deviceVerification.verify.useMutation()
+	const router = useRouter()
+	const [animate, setAnimate] = React.useState(false)
+	return (
+		<main className="mx-auto flex w-full max-w-lg flex-grow flex-col items-center justify-center pb-24 pt-16">
+			<div className="flex w-full flex-col items-center rounded p-5 text-center">
+				<Fingerprint animate={animate} />
+				<h1 className="text-2xl font-bold sm:text-3xl">Device Confirmation</h1>
+				<p className="py-4 text-gray-600 dark:text-gray-400">
+					Please confirm this is the code displayed in your Workshop App
+				</p>
+				<div className="w-full rounded-md border px-5 py-3 text-lg font-semibold dark:border-transparent dark:bg-black/75">
+					{userCode}
+				</div>
+				<Button
+					onMouseOver={() => {
+						setAnimate(true)
+					}}
+					onMouseOut={() => {
+						setAnimate(false)
+					}}
+					onClick={async () => {
+						verifyDeviceMutation.mutate(
+							{ userCode },
+							{
+								onSettled: (data) => {
+									switch (data?.status) {
+										case 'device-verified':
+											router.push('/activate/success')
+											break
+										case 'already-verified':
+											router.push(
+												'/activate/failure?message=Device already verified.',
+											)
+											break
+										case 'code-expired':
+											router.push('/activate/failure?message=Code expired.')
+											break
+										case 'no-verification-found':
+											router.push(
+												'/activate/failure?message=No verification found.',
+											)
+											break
+									}
+								},
+							},
+						)
+					}}
+					className="mt-8 font-semibold transition hover:brightness-110"
+				>
+					Confirm Device
+				</Button>
+			</div>
+		</main>
+	)
+}
+const Fingerprint: React.FC<{ animate: boolean }> = ({ animate }) => {
+	return (
+		<div className="relative mb-5 flex items-center justify-center">
+			<motion.div
+				animate={{
+					scale: animate ? 1 : 0,
+				}}
+				transition={{
+					duration: 1,
+					type: 'spring',
+					bounce: 0.25,
+				}}
+				className="absolute h-10 w-10 rounded-full bg-blue-500 mix-blend-overlay dark:bg-blue-400 dark:mix-blend-overlay"
+			/>
+			<svg
+				className={cn('h-10 w-10 text-gray-400 dark:text-gray-500')}
+				aria-hidden
+				viewBox="0 0 24 24"
+				xmlns="http://www.w3.org/2000/svg"
+			>
+				<g fill="none">
+					<path
+						d="M17.81 4.47c-.08 0-.16-.02-.23-.06C15.66 3.42 14 3 12.01 3c-1.98 0-3.86.47-5.57 1.41-.24.13-.54.04-.68-.2a.506.506 0 0 1 .2-.68C7.82 2.52 9.86 2 12.01 2c2.13 0 3.99.47 6.03 1.52.25.13.34.43.21.67a.49.49 0 0 1-.44.28zM3.5 9.72a.499.499 0 0 1-.41-.79c.99-1.4 2.25-2.5 3.75-3.27C9.98 4.04 14 4.03 17.15 5.65c1.5.77 2.76 1.86 3.75 3.25a.5.5 0 0 1-.12.7c-.23.16-.54.11-.7-.12a9.388 9.388 0 0 0-3.39-2.94c-2.87-1.47-6.54-1.47-9.4.01-1.36.7-2.5 1.7-3.4 2.96-.08.14-.23.21-.39.21zm6.25 12.07a.47.47 0 0 1-.35-.15c-.87-.87-1.34-1.43-2.01-2.64-.69-1.23-1.05-2.73-1.05-4.34 0-2.97 2.54-5.39 5.66-5.39s5.66 2.42 5.66 5.39c0 .28-.22.5-.5.5s-.5-.22-.5-.5c0-2.42-2.09-4.39-4.66-4.39-2.57 0-4.66 1.97-4.66 4.39 0 1.44.32 2.77.93 3.85.64 1.15 1.08 1.64 1.85 2.42.19.2.19.51 0 .71-.11.1-.24.15-.37.15zm7.17-1.85c-1.19 0-2.24-.3-3.1-.89-1.49-1.01-2.38-2.65-2.38-4.39 0-.28.22-.5.5-.5s.5.22.5.5c0 1.41.72 2.74 1.94 3.56.71.48 1.54.71 2.54.71.24 0 .64-.03 1.04-.1.27-.05.53.13.58.41.05.27-.13.53-.41.58-.57.11-1.07.12-1.21.12zM14.91 22c-.04 0-.09-.01-.13-.02-1.59-.44-2.63-1.03-3.72-2.1a7.297 7.297 0 0 1-2.17-5.22c0-1.62 1.38-2.94 3.08-2.94 1.7 0 3.08 1.32 3.08 2.94 0 1.07.93 1.94 2.08 1.94s2.08-.87 2.08-1.94c0-3.77-3.25-6.83-7.25-6.83-2.84 0-5.44 1.58-6.61 4.03-.39.81-.59 1.76-.59 2.8 0 .78.07 2.01.67 3.61.1.26-.03.55-.29.64-.26.1-.55-.04-.64-.29a11.14 11.14 0 0 1-.73-3.96c0-1.2.23-2.29.68-3.24 1.33-2.79 4.28-4.6 7.51-4.6 4.55 0 8.25 3.51 8.25 7.83 0 1.62-1.38 2.94-3.08 2.94-1.7 0-3.08-1.32-3.08-2.94 0-1.07-.93-1.94-2.08-1.94s-2.08.87-2.08 1.94c0 1.71.66 3.31 1.87 4.51.95.94 1.86 1.46 3.27 1.85.27.07.42.35.35.61-.05.23-.26.38-.47.38z"
+						fill="currentColor"
+					/>
+				</g>
+			</svg>
+		</div>
+	)
+}

--- a/apps/ai-hero/src/app/(user)/activate/failure/page.tsx
+++ b/apps/ai-hero/src/app/(user)/activate/failure/page.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import * as React from 'react'
+import { useSearchParams } from 'next/navigation'
+import { XCircleIcon } from '@heroicons/react/24/solid'
+import Balancer from 'react-wrap-balancer'
+
+export default function ActivateFailure() {
+	return (
+		<main className="mx-auto flex w-full max-w-lg flex-grow flex-col items-center justify-center pb-24 pt-16">
+			<div className="flex w-full flex-col items-center rounded p-5 text-center">
+				<XCircleIcon className="mb-5 h-10 w-10 text-rose-600 dark:text-rose-400" />
+				<h1 className="text-2xl font-bold sm:text-3xl">
+					Device Activation Failed
+				</h1>
+				<p className="w-full py-4 text-gray-600 dark:text-gray-400">
+					<React.Suspense>
+						<Message />
+					</React.Suspense>
+				</p>
+			</div>
+		</main>
+	)
+}
+
+function Message() {
+	const searchParams = useSearchParams()
+
+	const message = searchParams.get('message') || 'Unable to verify.'
+	return <Balancer>{message} Please try again.</Balancer>
+}

--- a/apps/ai-hero/src/app/(user)/activate/page.tsx
+++ b/apps/ai-hero/src/app/(user)/activate/page.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react'
+import { redirect } from 'next/navigation'
+import { getServerAuthSession } from '@/server/auth'
+
+import Verify from './_components/verifiy'
+
+export default async function Activate(props: {
+	searchParams: Promise<{ user_code: string }>
+}) {
+	const searchParams = await props.searchParams
+	const { session } = await getServerAuthSession()
+	const userCode = searchParams.user_code
+	const unAuthedCallbackUrl = `/activate%3Fuser_code=${userCode}`
+
+	if (!session) {
+		redirect(
+			`/login?callbackUrl=${unAuthedCallbackUrl}&message=You must be logged in to activate your device.`,
+		)
+	}
+
+	return <Verify userCode={userCode} />
+}

--- a/apps/ai-hero/src/app/(user)/activate/success/page.tsx
+++ b/apps/ai-hero/src/app/(user)/activate/success/page.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react'
+import { Icon } from '@/components/icons'
+import Balancer from 'react-wrap-balancer'
+
+export default function ActivateSuccess() {
+	return (
+		<main className="mx-auto flex w-full max-w-lg flex-grow flex-col items-center justify-center pb-24 pt-16">
+			<div className="flex w-full flex-col items-center rounded p-5 text-center">
+				<Icon
+					name="Checkmark"
+					className="mb-5 h-8 w-8 text-emerald-500 dark:text-emerald-300"
+				/>
+				<h1 className="text-2xl font-bold sm:text-3xl">
+					Device Activation Successful
+				</h1>
+				<p className="py-4 text-gray-600 dark:text-gray-400">
+					<Balancer>
+						You're now logged in to the workshop app. You can close this page.
+					</Balancer>
+				</p>
+			</div>
+		</main>
+	)
+}

--- a/apps/ai-hero/src/app/(user)/activate/success/page.tsx
+++ b/apps/ai-hero/src/app/(user)/activate/success/page.tsx
@@ -15,7 +15,7 @@ export default function ActivateSuccess() {
 				</h1>
 				<p className="py-4 text-gray-600 dark:text-gray-400">
 					<Balancer>
-						You're now logged in to the workshop app. You can close this page.
+						You're now logged in to the app. You can close this page.
 					</Balancer>
 				</p>
 			</div>

--- a/apps/ai-hero/src/app/(user)/profile/page.tsx
+++ b/apps/ai-hero/src/app/(user)/profile/page.tsx
@@ -14,6 +14,10 @@ export default async function ProfilePage() {
 		redirect('/')
 	}
 
+	if (!session) {
+		return redirect('/')
+	}
+
 	if (!session.user) {
 		notFound()
 	}

--- a/apps/ai-hero/src/app/api/posts/route.ts
+++ b/apps/ai-hero/src/app/api/posts/route.ts
@@ -1,0 +1,206 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { courseBuilderAdapter } from '@/db'
+import { NewPostSchema, PostActionSchema, PostUpdateSchema } from '@/lib/posts'
+import {
+	deletePostFromDatabase,
+	getAllPostsForUser,
+	getPost,
+	writeNewPostToDatabase,
+	writePostUpdateToDatabase,
+} from '@/lib/posts-query'
+import { getUserAbilityForRequest } from '@/server/ability-for-request'
+import { subject } from '@casl/ability'
+
+const corsHeaders = {
+	'Access-Control-Allow-Origin': '*',
+	'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+	'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+}
+
+export async function OPTIONS() {
+	return NextResponse.json({}, { headers: corsHeaders })
+}
+
+export async function GET(request: NextRequest) {
+	const { ability, user } = await getUserAbilityForRequest(request)
+	const { searchParams } = new URL(request.url)
+	const slug = searchParams.get('slug')
+
+	if (slug) {
+		const post = await getPost(slug)
+		if (!post) {
+			return NextResponse.json(
+				{ error: 'Post not found' },
+				{ status: 404, headers: corsHeaders },
+			)
+		}
+		if (ability.can('read', subject('Content', post))) {
+			return NextResponse.json(post, { headers: corsHeaders })
+		}
+		return NextResponse.json(
+			{ error: 'Unauthorized' },
+			{ status: 401, headers: corsHeaders },
+		)
+	}
+
+	if (ability.cannot('read', 'Content')) {
+		return NextResponse.json(
+			{ error: 'Unauthorized' },
+			{ status: 401, headers: corsHeaders },
+		)
+	}
+
+	const posts = await getAllPostsForUser(user?.id)
+	return NextResponse.json(posts, { headers: corsHeaders })
+}
+
+export async function POST(request: NextRequest) {
+	const { ability, user } = await getUserAbilityForRequest(request)
+
+	if (ability.cannot('create', 'Content')) {
+		return NextResponse.json(
+			{ error: 'Unauthorized' },
+			{ status: 401, headers: corsHeaders },
+		)
+	}
+
+	if (!user) {
+		return NextResponse.json(
+			{ error: 'Unauthorized' },
+			{ status: 401, headers: corsHeaders },
+		)
+	}
+
+	const body = await request.json()
+	const validatedData = NewPostSchema.safeParse(body)
+
+	if (!validatedData.success) {
+		return NextResponse.json(
+			{ error: validatedData.error },
+			{ status: 400, headers: corsHeaders },
+		)
+	}
+
+	try {
+		const newPost = await writeNewPostToDatabase({
+			title: validatedData.data.title,
+			videoResourceId: validatedData.data.videoResourceId || undefined,
+			postType: validatedData.data.postType,
+			createdById: user.id,
+		})
+		return NextResponse.json(newPost, { status: 201, headers: corsHeaders })
+	} catch (error) {
+		return NextResponse.json(
+			{ error: 'Failed to create post' },
+			{ status: 500, headers: corsHeaders },
+		)
+	}
+}
+
+export async function PUT(request: NextRequest) {
+	const body = await request.json()
+	const { searchParams } = new URL(request.url)
+	const actionInput = PostActionSchema.safeParse(
+		searchParams.get('action') || 'save',
+	)
+
+	if (!actionInput.success) {
+		return NextResponse.json(
+			{ error: 'Invalid action' },
+			{ status: 400, headers: corsHeaders },
+		)
+	}
+
+	const action = actionInput.data
+
+	const { ability, user } = await getUserAbilityForRequest(request)
+
+	if (!user) {
+		return NextResponse.json(
+			{ error: 'Unauthorized' },
+			{ status: 401, headers: corsHeaders },
+		)
+	}
+
+	const validatedData = PostUpdateSchema.safeParse(body)
+
+	if (!validatedData.success) {
+		return NextResponse.json(
+			{ error: validatedData.error },
+			{ status: 400, headers: corsHeaders },
+		)
+	}
+
+	const originalPost = await getPost(validatedData.data.id)
+
+	if (!originalPost) {
+		return NextResponse.json(
+			{ error: 'Post not found' },
+			{ status: 404, headers: corsHeaders },
+		)
+	}
+
+	if (ability.cannot('manage', subject('Content', originalPost))) {
+		return NextResponse.json(
+			{ error: 'Unauthorized' },
+			{ status: 401, headers: corsHeaders },
+		)
+	}
+
+	try {
+		const updatedPost = await writePostUpdateToDatabase({
+			currentPost: originalPost,
+			postUpdate: validatedData.data,
+			action,
+			updatedById: user.id,
+		})
+		return NextResponse.json(updatedPost, { headers: corsHeaders })
+	} catch (error) {
+		console.error('Failed to update post', error)
+		return NextResponse.json(
+			{ error: 'Failed to update post' },
+			{ status: 500, headers: corsHeaders },
+		)
+	}
+}
+
+export async function DELETE(request: NextRequest) {
+	const { ability } = await getUserAbilityForRequest(request)
+	const { searchParams } = new URL(request.url)
+	const id = searchParams.get('id')
+
+	if (!id) {
+		return NextResponse.json(
+			{ error: 'Missing post ID' },
+			{ status: 400, headers: corsHeaders },
+		)
+	}
+	const postToDelete = await courseBuilderAdapter.getContentResource(id)
+
+	if (!postToDelete) {
+		return NextResponse.json(
+			{ error: 'Post not found' },
+			{ status: 404, headers: corsHeaders },
+		)
+	}
+
+	if (ability.cannot('delete', subject('Content', postToDelete))) {
+		return NextResponse.json(
+			{ error: 'Unauthorized' },
+			{ status: 401, headers: corsHeaders },
+		)
+	}
+
+	try {
+		await deletePostFromDatabase(id)
+		return NextResponse.json(
+			{ message: 'Post deleted successfully' },
+			{ headers: corsHeaders },
+		)
+	} catch (error) {
+		return NextResponse.json(
+			{ error: 'Failed to delete post' },
+			{ status: 500, headers: corsHeaders },
+		)
+	}
+}

--- a/apps/ai-hero/src/app/api/uploads/new/route.ts
+++ b/apps/ai-hero/src/app/api/uploads/new/route.ts
@@ -1,0 +1,69 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { inngest } from '@/inngest/inngest.server'
+import { getUserAbilityForRequest } from '@/server/ability-for-request'
+import { z } from 'zod'
+
+import { VIDEO_UPLOADED_EVENT } from '@coursebuilder/core/inngest/video-processing/events/event-video-uploaded'
+
+// Zod schema for the request body
+const UploadBodySchema = z.object({
+	file: z.object({
+		url: z.string().url(),
+		name: z.string().optional(),
+	}),
+	metadata: z.object({
+		parentResourceId: z.string(),
+	}),
+})
+
+const corsHeaders = {
+	'Access-Control-Allow-Origin': '*',
+	'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+	'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+}
+
+export const OPTIONS = async () => {
+	return NextResponse.json({}, { headers: corsHeaders })
+}
+
+export const POST = async (request: NextRequest) => {
+	const { user, ability } = await getUserAbilityForRequest(request)
+
+	if (ability.cannot('create', 'Content')) {
+		return NextResponse.json(
+			{ error: 'Unauthorized' },
+			{ status: 401, headers: corsHeaders },
+		)
+	}
+
+	try {
+		const body = await request.json()
+
+		// Validate the request body
+		const validatedBody = UploadBodySchema.parse(body)
+
+		await inngest.send({
+			name: VIDEO_UPLOADED_EVENT,
+			data: {
+				originalMediaUrl: validatedBody.file.url,
+				fileName: validatedBody.file.name || 'untitled',
+				title: validatedBody.file.name || 'untitled',
+				parentResourceId: validatedBody.metadata.parentResourceId,
+			},
+			user,
+		})
+
+		return NextResponse.json({ success: true }, { headers: corsHeaders })
+	} catch (error) {
+		if (error instanceof z.ZodError) {
+			return NextResponse.json(
+				{ error: error.errors },
+				{ status: 400, headers: corsHeaders },
+			)
+		}
+		return NextResponse.json(
+			{ error: 'Internal Server Error' },
+			{ status: 500, headers: corsHeaders },
+		)
+	}
+}

--- a/apps/ai-hero/src/app/api/uploads/signed-url/route.ts
+++ b/apps/ai-hero/src/app/api/uploads/signed-url/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getSignedUrlForVideoFile } from '@/video-uploader/get-signed-s3-url'
+
+export const GET = async (request: NextRequest) => {
+	const searchParams = new URL(request.url).searchParams
+	const filename = searchParams.get('objectName')
+
+	if (filename) {
+		const signedUrl = await getSignedUrlForVideoFile({ filename })
+		return NextResponse.json(signedUrl, {
+			status: 200,
+			headers: {
+				'Access-Control-Allow-Origin': '*',
+				'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+				'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+			},
+		})
+	}
+
+	return NextResponse.json(
+		{ error: 'No filename provided' },
+		{
+			status: 400,
+			headers: {
+				'Access-Control-Allow-Origin': '*',
+				'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+				'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+			},
+		},
+	)
+}

--- a/apps/ai-hero/src/app/api/videos/[videoResourceId]/route.ts
+++ b/apps/ai-hero/src/app/api/videos/[videoResourceId]/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getVideoResource } from '@/lib/video-resource-query'
+import { getUserAbilityForRequest } from '@/server/ability-for-request'
+
+const corsHeaders = {
+	'Access-Control-Allow-Origin': '*',
+	'Access-Control-Allow-Methods': 'GET, OPTIONS',
+	'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+}
+
+export async function OPTIONS() {
+	return NextResponse.json({}, { headers: corsHeaders })
+}
+
+export async function GET(
+	request: NextRequest,
+	props: { params: Promise<{ videoResourceId: string }> },
+) {
+	const params = await props.params
+	const { ability, user } = await getUserAbilityForRequest(request)
+
+	if (params.videoResourceId) {
+		const videoResource = await getVideoResource(params.videoResourceId)
+
+		if (!videoResource) {
+			return NextResponse.json(
+				{ error: 'videoResource not found' },
+				{
+					status: 404,
+					headers: corsHeaders,
+				},
+			)
+		}
+		if (ability.can('create', 'Content')) {
+			return NextResponse.json(videoResource, {
+				headers: corsHeaders,
+			})
+		}
+
+		return NextResponse.json(
+			{ error: 'Unauthorized' },
+			{
+				status: 401,
+				headers: corsHeaders,
+			},
+		)
+	}
+
+	return NextResponse.json({}, { headers: corsHeaders })
+}

--- a/apps/ai-hero/src/app/oauth/.well-known/openid-configuration/route.ts
+++ b/apps/ai-hero/src/app/oauth/.well-known/openid-configuration/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server'
+
+export async function GET() {
+	const config = {
+		token_endpoint: `${process.env.NEXT_PUBLIC_URL}/oauth/token`,
+		token_endpoint_auth_methods_supported: [],
+		response_types_supported: ['token'],
+		scopes_supported: ['content:read', 'progress'],
+		issuer: `${process.env.NEXT_PUBLIC_URL}/oauth`,
+		registration_endpoint: `${process.env.NEXT_PUBLIC_URL}/oauth/register`,
+		device_authorization_endpoint: `${process.env.NEXT_PUBLIC_URL}/oauth/device/code`,
+		claims_supported: ['email'],
+		userinfo_endpoint: `${process.env.NEXT_PUBLIC_URL}/oauth/userinfo`,
+	}
+
+	return NextResponse.json(config)
+}

--- a/apps/ai-hero/src/app/oauth/device/code/route.ts
+++ b/apps/ai-hero/src/app/oauth/device/code/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from 'next/server'
+import { db } from '@/db'
+import { deviceVerifications } from '@/db/schema'
+import { eq } from 'drizzle-orm'
+import { hri } from 'human-readable-ids'
+import { v4 } from 'uuid'
+
+export async function POST() {
+	const TEN_MINUTES_IN_MILLISECONDS = 60 * 10 * 1000
+	const expires = new Date(Date.now() + TEN_MINUTES_IN_MILLISECONDS + 10000)
+
+	const userCode = hri.random()
+	const deviceCode = v4()
+
+	await db.insert(deviceVerifications).values({
+		userCode,
+		deviceCode,
+		createdAt: new Date(),
+		expires,
+	})
+
+	const deviceVerification = await db.query.deviceVerifications.findFirst({
+		where: eq(deviceVerifications.deviceCode, deviceCode),
+	})
+
+	if (!deviceVerification) {
+		return NextResponse.json(
+			{ error: 'Device verification not found' },
+			{ status: 404 },
+		)
+	}
+
+	return NextResponse.json({
+		device_code: deviceVerification.deviceCode,
+		user_code: deviceVerification.userCode,
+		verification_uri: `${process.env.NEXT_PUBLIC_URL}/activate`,
+		verification_uri_complete: `${process.env.NEXT_PUBLIC_URL}/activate?user_code=${deviceVerification.userCode}`,
+		expires_in: TEN_MINUTES_IN_MILLISECONDS / 1000,
+		interval: 5,
+	})
+}

--- a/apps/ai-hero/src/app/oauth/register/route.ts
+++ b/apps/ai-hero/src/app/oauth/register/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server'
+import { customAlphabet } from 'nanoid'
+
+const nanoid = customAlphabet('ABCDEFGHIJKLMNOP', 6)
+export async function POST() {
+	return NextResponse.json(
+		{
+			client_id: nanoid(),
+			client_secret: nanoid(),
+		},
+		{ status: 201 },
+	)
+}

--- a/apps/ai-hero/src/app/oauth/token/route.ts
+++ b/apps/ai-hero/src/app/oauth/token/route.ts
@@ -1,0 +1,90 @@
+import { NextResponse } from 'next/server'
+import { getUser } from '@/app/oauth/userinfo/get-user'
+import { db } from '@/db'
+import { deviceAccessToken, deviceVerifications } from '@/db/schema'
+import { eq } from 'drizzle-orm'
+
+export async function POST(request: Request) {
+	const formData = await request.formData()
+	const device_code = formData.get('device_code')
+
+	const deviceVerification = await db.query.deviceVerifications.findFirst({
+		where: eq(deviceVerifications.deviceCode, device_code as string),
+	})
+
+	if (deviceVerification) {
+		if (
+			!deviceVerification.verifiedAt &&
+			new Date() > deviceVerification.expires
+		) {
+			return NextResponse.json(
+				{
+					error: 'expired_token',
+					error_description: 'The device verification has expired',
+				},
+				{ status: 403 },
+			)
+		}
+
+		if (!deviceVerification.verifiedAt) {
+			return NextResponse.json(
+				{
+					error: 'authorization_pending',
+					error_description: 'The device verification is pending',
+				},
+				{ status: 403 },
+			)
+		}
+
+		const user = await getUser(deviceVerification.verifiedByUserId)
+
+		if (user) {
+			await db.insert(deviceAccessToken).values({
+				userId: user.id,
+				token: crypto.randomUUID(),
+			})
+
+			const deviceToken = await db.query.deviceAccessToken.findFirst({
+				where: eq(deviceAccessToken.userId, user.id),
+			})
+
+			await db
+				.delete(deviceVerifications)
+				.where(
+					eq(deviceVerifications.deviceCode, deviceVerification.deviceCode),
+				)
+
+			if (!deviceToken) {
+				return NextResponse.json(
+					{
+						error: 'access_denied',
+						error_description: 'Device token not found',
+					},
+					{ status: 403 },
+				)
+			}
+
+			return NextResponse.json({
+				access_token: deviceToken.token,
+				token_type: 'bearer',
+				scope: 'content:read progress',
+			})
+		} else {
+			return NextResponse.json(
+				{
+					error: 'access_denied',
+					error_description: 'User not found',
+				},
+				{ status: 403 },
+			)
+		}
+	} else {
+		return NextResponse.json(
+			{
+				error: 'access_denied',
+				error_description: 'The device code is invalid',
+			},
+			{ status: 403 },
+		)
+	}
+}

--- a/apps/ai-hero/src/app/oauth/userinfo/get-user.ts
+++ b/apps/ai-hero/src/app/oauth/userinfo/get-user.ts
@@ -1,0 +1,12 @@
+import { db } from '@/db'
+import { users } from '@/db/schema'
+import { eq } from 'drizzle-orm'
+
+export async function getUser(userId: string | null) {
+	if (!userId) {
+		return null
+	}
+	return db.query.users.findFirst({
+		where: eq(users.id, userId),
+	})
+}

--- a/apps/ai-hero/src/app/oauth/userinfo/route.ts
+++ b/apps/ai-hero/src/app/oauth/userinfo/route.ts
@@ -1,0 +1,39 @@
+import { headers } from 'next/headers'
+import { NextResponse } from 'next/server'
+import { db } from '@/db'
+import { deviceAccessToken as deviceAccessTokenTable } from '@/db/schema'
+import { eq } from 'drizzle-orm'
+
+import { getUser } from './get-user'
+
+export async function GET(request: Request) {
+	const headersList = await headers()
+	const deviceAccessToken = headersList.get('Authorization')?.split(' ')[1]
+
+	if (deviceAccessToken) {
+		const token = await db.query.deviceAccessToken.findFirst({
+			where: eq(deviceAccessTokenTable.token, deviceAccessToken),
+		})
+		if (token?.userId) {
+			const user = await getUser(token.userId)
+
+			return NextResponse.json({ ...user })
+		} else {
+			return NextResponse.json(
+				{
+					error: 'not_found',
+					error_description: 'User not found.',
+				},
+				{ status: 404 },
+			)
+		}
+	} else {
+		return NextResponse.json(
+			{
+				error: 'access_denied',
+				error_description: 'Nothing to see here.',
+			},
+			{ status: 403 },
+		)
+	}
+}

--- a/apps/ai-hero/src/components/feedback-widget/feedback-actions.ts
+++ b/apps/ai-hero/src/components/feedback-widget/feedback-actions.ts
@@ -28,7 +28,7 @@ export async function sendFeedbackFromUser({
 	try {
 		const { session } = await getServerAuthSession()
 		const user = (await db.query.users.findFirst({
-			where: eq(users.email, session.user?.email?.toLowerCase() || 'NO-EMAIL'),
+			where: eq(users.email, session?.user?.email?.toLowerCase() || 'NO-EMAIL'),
 		})) || { email: emailAddress, id: null, name: null }
 
 		if (!user.email) {

--- a/apps/ai-hero/src/components/resources-crud/new-lesson-video-form.tsx
+++ b/apps/ai-hero/src/components/resources-crud/new-lesson-video-form.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react'
+import { useRouter } from 'next/navigation'
+import { VideoUploader } from '@/components/resources-crud/video-uploader'
+import { pollVideoResource } from '@/utils/poll-video-resource'
+
+export function NewLessonVideoForm({
+	parentResourceId,
+	onVideoResourceCreated,
+	onVideoUploadCompleted,
+}: {
+	parentResourceId: string
+	onVideoResourceCreated: (videoResourceId: string) => void
+	onVideoUploadCompleted: (videoResourceId: string) => void
+}) {
+	const router = useRouter()
+
+	async function handleSetVideoResourceId(videoResourceId: string) {
+		try {
+			onVideoUploadCompleted(videoResourceId)
+			await pollVideoResource(videoResourceId).next()
+			onVideoResourceCreated(videoResourceId)
+			router.refresh()
+		} catch (error) {}
+	}
+
+	return (
+		<VideoUploader
+			setVideoResourceId={handleSetVideoResourceId}
+			parentResourceId={parentResourceId}
+		/>
+	)
+}

--- a/apps/ai-hero/src/components/resources-crud/new-resource-with-video-form.tsx
+++ b/apps/ai-hero/src/components/resources-crud/new-resource-with-video-form.tsx
@@ -1,0 +1,253 @@
+'use client'
+
+import * as React from 'react'
+import { NewPost, PostType, PostTypeSchema } from '@/lib/posts'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+
+import {
+	type ContentResource,
+	type VideoResource,
+} from '@coursebuilder/core/schemas'
+import {
+	Button,
+	Form,
+	FormControl,
+	FormDescription,
+	FormField,
+	FormItem,
+	FormLabel,
+	FormMessage,
+	Input,
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from '@coursebuilder/ui'
+import { cn } from '@coursebuilder/ui/utils/cn'
+
+import { VideoUploadFormItem } from './video-upload-form-item'
+
+const NewResourceWithVideoSchema = z.object({
+	title: z.string().min(2).max(90),
+	videoResourceId: z.string().min(4, 'Please upload a video'),
+})
+
+type NewResourceWithVideo = z.infer<typeof NewResourceWithVideoSchema>
+
+const FormValuesSchema = NewResourceWithVideoSchema.extend({
+	postType: PostTypeSchema,
+	videoResourceId: z.string().optional(),
+})
+
+type FormValues = z.infer<typeof FormValuesSchema>
+
+export function NewResourceWithVideoForm({
+	getVideoResource,
+	createResource,
+	onResourceCreated,
+	availableResourceTypes,
+	className,
+	children,
+	uploadEnabled = true,
+}: {
+	getVideoResource: (idOrSlug?: string) => Promise<VideoResource | null>
+	createResource: (values: NewPost) => Promise<ContentResource>
+	onResourceCreated: (resource: ContentResource, title: string) => Promise<void>
+	availableResourceTypes?: PostType[] | undefined
+	className?: string
+	children: (
+		handleSetVideoResourceId: (value: string) => void,
+	) => React.ReactNode
+	uploadEnabled?: boolean
+}) {
+	const [videoResourceId, setVideoResourceId] = React.useState<
+		string | undefined
+	>()
+	const [videoResourceValid, setVideoResourceValid] =
+		React.useState<boolean>(false)
+	const [isValidatingVideoResource, setIsValidatingVideoResource] =
+		React.useState<boolean>(false)
+
+	const form = useForm<FormValues>({
+		resolver: zodResolver(FormValuesSchema),
+		defaultValues: {
+			title: '',
+			videoResourceId: undefined,
+			postType: availableResourceTypes?.[0] || 'lesson',
+		},
+	})
+
+	async function* pollVideoResource(
+		videoResourceId: string,
+		maxAttempts = 30,
+		initialDelay = 250,
+		delayIncrement = 250,
+	) {
+		let delay = initialDelay
+
+		for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+			const videoResource = await getVideoResource(videoResourceId)
+			if (videoResource) {
+				yield videoResource
+				return
+			}
+
+			await new Promise((resolve) => setTimeout(resolve, delay))
+			delay += delayIncrement
+		}
+
+		throw new Error('Video resource not found after maximum attempts')
+	}
+
+	const [isSubmitting, setIsSubmitting] = React.useState(false)
+
+	const onSubmit = async (values: FormValues) => {
+		try {
+			setIsSubmitting(true)
+			if (values.videoResourceId) {
+				await pollVideoResource(values.videoResourceId).next()
+			}
+			const resource = await createResource(values as any)
+			if (!resource) {
+				// Handle edge case, e.g., toast an error message
+				console.log('no resource in onSubmit')
+				return
+			}
+
+			onResourceCreated(resource, form.watch('title'))
+		} catch (error) {
+			console.error('Error polling video resource:', error)
+			// handle error, e.g. toast an error message
+		} finally {
+			form.reset()
+			setVideoResourceId(videoResourceId)
+			form.setValue('videoResourceId', '')
+			setIsSubmitting(false)
+		}
+	}
+
+	async function handleSetVideoResourceId(videoResourceId: string) {
+		try {
+			setVideoResourceId(videoResourceId)
+			setIsValidatingVideoResource(true)
+			form.setValue('videoResourceId', videoResourceId)
+			await pollVideoResource(videoResourceId).next()
+
+			setVideoResourceValid(true)
+			setIsValidatingVideoResource(false)
+		} catch (error) {
+			setVideoResourceValid(false)
+			form.setError('videoResourceId', { message: 'Video resource not found' })
+			setVideoResourceId('')
+			form.setValue('videoResourceId', '')
+			setIsValidatingVideoResource(false)
+		}
+	}
+
+	const selectedPostType = form.watch('postType')
+
+	return (
+		<Form {...form}>
+			<form
+				onSubmit={form.handleSubmit(onSubmit)}
+				className={cn('flex flex-col gap-5', className)}
+			>
+				<FormField
+					control={form.control}
+					name="title"
+					render={({ field }) => (
+						<FormItem>
+							<FormLabel>Title</FormLabel>
+							<FormDescription>
+								A title should summarize the resource and explain what it is
+								about clearly.
+							</FormDescription>
+							<FormControl>
+								<Input {...field} />
+							</FormControl>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+				{availableResourceTypes && (
+					<FormField
+						control={form.control}
+						name="postType"
+						render={({ field }) => {
+							const descriptions = {
+								lesson:
+									'A traditional egghead lesson video. (upload on next screen)',
+								article: 'A standard article',
+								podcast:
+									'A podcast episode that will be distributed across podcast networks via the egghead podcast',
+								course:
+									'A collection of lessons that will be distributed as a course',
+							}
+
+							return (
+								<FormItem>
+									<FormLabel>Type</FormLabel>
+									<FormDescription>
+										Select the type of resource you are creating.
+									</FormDescription>
+									<FormControl>
+										<Select
+											onValueChange={field.onChange}
+											defaultValue={field.value}
+										>
+											<SelectTrigger className="capitalize">
+												<SelectValue placeholder="Select Type..." />
+											</SelectTrigger>
+											<SelectContent>
+												{availableResourceTypes.map((type) => (
+													<SelectItem
+														className="capitalize"
+														value={type}
+														key={type}
+													>
+														{type}
+													</SelectItem>
+												))}
+											</SelectContent>
+										</Select>
+									</FormControl>
+									{field.value && (
+										<div className="bg-muted text-muted-foreground mx-auto mt-2 max-w-[300px] whitespace-normal break-words rounded-md p-3 py-2 text-sm">
+											{descriptions[field.value as keyof typeof descriptions]}
+										</div>
+									)}
+									<FormMessage />
+								</FormItem>
+							)
+						}}
+					/>
+				)}
+				{uploadEnabled && (
+					<VideoUploadFormItem
+						selectedPostType={selectedPostType}
+						form={form}
+						videoResourceId={videoResourceId}
+						setVideoResourceId={setVideoResourceId}
+						handleSetVideoResourceId={handleSetVideoResourceId}
+						isValidatingVideoResource={isValidatingVideoResource}
+						videoResourceValid={videoResourceValid}
+					>
+						{children}
+					</VideoUploadFormItem>
+				)}
+				<Button
+					type="submit"
+					variant="default"
+					disabled={
+						(videoResourceId ? !videoResourceValid : false) || isSubmitting
+					}
+				>
+					{isSubmitting ? 'Creating...' : 'Create Draft Resource'}
+				</Button>
+			</form>
+		</Form>
+	)
+}

--- a/apps/ai-hero/src/components/resources-crud/video-upload-form-item.tsx
+++ b/apps/ai-hero/src/components/resources-crud/video-upload-form-item.tsx
@@ -1,0 +1,87 @@
+import { POST_TYPES_WITH_VIDEO, PostType } from '@/lib/posts'
+import { FileVideo } from 'lucide-react'
+import { UseFormReturn } from 'react-hook-form'
+
+import { Button } from '@coursebuilder/ui/primitives/button'
+import {
+	FormControl,
+	FormDescription,
+	FormField,
+	FormItem,
+	FormLabel,
+	FormMessage,
+} from '@coursebuilder/ui/primitives/form'
+import { Input } from '@coursebuilder/ui/primitives/input'
+
+export function VideoUploadFormItem({
+	selectedPostType,
+	form,
+	videoResourceId,
+	setVideoResourceId,
+	children,
+	handleSetVideoResourceId,
+	isValidatingVideoResource,
+	videoResourceValid,
+}: {
+	selectedPostType: PostType
+	form: UseFormReturn<any>
+	videoResourceId?: string
+	setVideoResourceId: (id: string) => void
+	children: (handleSetVideoResourceId: (id: string) => void) => React.ReactNode
+	handleSetVideoResourceId: (id: string) => void
+	isValidatingVideoResource: boolean
+	videoResourceValid: boolean
+}) {
+	return (
+		POST_TYPES_WITH_VIDEO.includes(selectedPostType) && (
+			<FormField
+				control={form.control}
+				name="videoResourceId"
+				render={({ field }) => (
+					<FormItem>
+						<FormLabel>
+							{videoResourceId ? 'Video' : 'Upload a Video'}
+						</FormLabel>
+						<FormDescription>
+							<span className="block">
+								You can upload a video later if needed.
+							</span>
+							Your video will be uploaded and then transcribed automatically.
+						</FormDescription>
+						<FormControl>
+							<Input type="hidden" {...field} />
+						</FormControl>
+						{!videoResourceId ? (
+							children(handleSetVideoResourceId)
+						) : (
+							<div className="mt-5 flex w-full justify-between border-t pt-5">
+								<div className="flex flex-col divide-y">
+									<span className="text-primary flex items-center gap-2 py-1 text-sm">
+										<FileVideo className="h-4 w-4" />
+										<span>{videoResourceId}</span>
+									</span>
+								</div>
+								<Button
+									type="button"
+									variant="outline"
+									size="sm"
+									onClick={() => {
+										setVideoResourceId('')
+										form.setValue('videoResourceId', '')
+									}}
+								>
+									clear
+								</Button>
+							</div>
+						)}
+						{isValidatingVideoResource && !videoResourceValid ? (
+							<FormMessage>Processing Upload</FormMessage>
+						) : null}
+
+						<FormMessage />
+					</FormItem>
+				)}
+			/>
+		)
+	)
+}

--- a/apps/ai-hero/src/components/resources-crud/video-uploader.tsx
+++ b/apps/ai-hero/src/components/resources-crud/video-uploader.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react'
+import { getUniqueFilename } from '@/utils/get-unique-filename'
+import { UploadDropzone } from '@/utils/uploadthing'
+
+export function VideoUploader({
+	setVideoResourceId,
+	parentResourceId,
+}: {
+	setVideoResourceId: (value: string) => void
+	parentResourceId?: string
+}) {
+	return (
+		<div>
+			<UploadDropzone
+				input={{ parentResourceId }}
+				endpoint="videoUploader"
+				config={{
+					mode: 'auto',
+				}}
+				onBeforeUploadBegin={(files) => {
+					return files.map(
+						(file) =>
+							new File([file], getUniqueFilename(file.name), {
+								type: file.type,
+							}),
+					)
+				}}
+				onClientUploadComplete={async (response: any) => {
+					if (response[0].name) setVideoResourceId(response[0].name)
+				}}
+				className="[&_label]:text-primary [&_label]:hover:text-primary border-border"
+				onUploadError={(error: Error) => {
+					// Do something with the error.
+					console.log(`ERROR! ${error.message}`)
+				}}
+			/>
+		</div>
+	)
+}

--- a/apps/ai-hero/src/db/schema.ts
+++ b/apps/ai-hero/src/db/schema.ts
@@ -78,4 +78,8 @@ export const {
 	merchantSubscriptionRelations,
 	subscription,
 	subscriptionRelations,
+	deviceVerifications,
+	deviceVerificationRelations,
+	deviceAccessToken,
+	deviceAccessTokenRelations,
 } = getCourseBuilderSchema(mysqlTable)

--- a/apps/ai-hero/src/lib/discord-query.ts
+++ b/apps/ai-hero/src/lib/discord-query.ts
@@ -16,7 +16,7 @@ export async function getDiscordAccount(userId: string) {
 
 export async function disconnectDiscord() {
 	const { session } = await getServerAuthSession()
-	if (!session.user) return false
+	if (!session?.user) return false
 
 	const user = await db.query.users.findFirst({
 		where: eq(users.id, session.user.id),

--- a/apps/ai-hero/src/lib/pages.ts
+++ b/apps/ai-hero/src/lib/pages.ts
@@ -31,7 +31,7 @@ export const PageSchema = ContentResourceSchema.merge(
 			description: z.string().optional(),
 			slug: z.string(),
 			state: PageStateSchema.default('draft'),
-			visibility: ResourceVisibilitySchema.default('unlisted'),
+			visibility: ResourceVisibilitySchema.default('public'),
 			socialImage: z
 				.object({
 					type: z.string(),

--- a/apps/ai-hero/src/lib/post-errors.ts
+++ b/apps/ai-hero/src/lib/post-errors.ts
@@ -1,0 +1,21 @@
+export class PostCreationError extends Error {
+	constructor(
+		message: string,
+		public readonly cause?: unknown,
+		public readonly context?: Record<string, unknown>,
+	) {
+		super(message)
+		this.name = 'PostCreationError'
+	}
+}
+
+export class DatabaseError extends PostCreationError {
+	constructor(
+		operation: string,
+		cause?: unknown,
+		context?: Record<string, unknown>,
+	) {
+		super(`Database operation failed: ${operation}`, cause, context)
+		this.name = 'DatabaseError'
+	}
+}

--- a/apps/ai-hero/src/lib/post-utils.ts
+++ b/apps/ai-hero/src/lib/post-utils.ts
@@ -1,0 +1,23 @@
+import crypto from 'node:crypto'
+import { guid } from '@/utils/guid'
+import slugify from '@sindresorhus/slugify'
+
+import { type Post } from './posts'
+
+export function updatePostSlug(currentPost: Post, newTitle: string): string {
+	if (newTitle !== currentPost.fields.title) {
+		const splitSlug = currentPost?.fields.slug.split('~') || ['', guid()]
+		return `${slugify(newTitle)}~${splitSlug[1] || guid()}`
+	}
+	return currentPost.fields.slug
+}
+
+export function generateContentHash(post: Post): string {
+	const content = JSON.stringify({
+		title: post.fields.title,
+		body: post.fields.body,
+		description: post.fields.description,
+		slug: post.fields.slug,
+	})
+	return crypto.createHash('sha256').update(content).digest('hex')
+}

--- a/apps/ai-hero/src/lib/post-utils.ts
+++ b/apps/ai-hero/src/lib/post-utils.ts
@@ -1,4 +1,4 @@
-import crypto from 'node:crypto'
+import crypto from 'crypto'
 import { guid } from '@/utils/guid'
 import slugify from '@sindresorhus/slugify'
 

--- a/apps/ai-hero/src/lib/posts-query.ts
+++ b/apps/ai-hero/src/lib/posts-query.ts
@@ -1,20 +1,34 @@
 'use server'
 
+import crypto from 'node:crypto'
 import { revalidatePath, revalidateTag, unstable_cache } from 'next/cache'
+import { redirect } from 'next/navigation'
 import { courseBuilderAdapter, db } from '@/db'
 import {
+	contentContributions,
 	contentResource,
 	contentResourceResource,
 	contentResourceTag as contentResourceTagTable,
+	contentResourceVersion as contentResourceVersionTable,
+	contributionTypes,
 } from '@/db/schema'
-import { NewPost, Post, PostSchema, type PostUpdate } from '@/lib/posts'
+import {
+	NewPost,
+	Post,
+	PostAction,
+	PostSchema,
+	type PostUpdate,
+} from '@/lib/posts'
 import { getServerAuthSession } from '@/server/auth'
 import { guid } from '@/utils/guid'
 import { subject } from '@casl/ability'
 import slugify from '@sindresorhus/slugify'
 import { and, asc, desc, eq, inArray, or, sql } from 'drizzle-orm'
+import readingTime from 'reading-time'
 import { v4 } from 'uuid'
 import { z } from 'zod'
+
+import { getMuxAsset } from '@coursebuilder/core/lib/mux'
 
 import { TagSchema, type Tag } from './tags'
 import { deletePostInTypeSense, upsertPostToTypeSense } from './typesense-query'
@@ -28,6 +42,42 @@ export const getCachedAllPosts = unstable_cache(
 export async function getAllPosts(): Promise<Post[]> {
 	const posts = await db.query.contentResource.findMany({
 		where: eq(contentResource.type, 'post'),
+		orderBy: desc(contentResource.createdAt),
+	})
+
+	const postsParsed = z.array(PostSchema).safeParse(posts)
+	if (!postsParsed.success) {
+		console.error('Error parsing posts', postsParsed.error)
+		return []
+	}
+
+	return postsParsed.data
+}
+
+export async function getAllPostsForUser(userId?: string): Promise<Post[]> {
+	if (!userId) {
+		redirect('/')
+	}
+
+	const posts = await db.query.contentResource.findMany({
+		where: and(
+			eq(contentResource.type, 'post'),
+			eq(contentResource.createdById, userId),
+		),
+		with: {
+			tags: {
+				with: {
+					tag: true,
+				},
+				orderBy: asc(contentResourceTagTable.position),
+			},
+			resources: {
+				with: {
+					resource: true,
+				},
+				orderBy: asc(contentResourceResource.position),
+			},
+		},
 		orderBy: desc(contentResource.createdAt),
 	})
 
@@ -316,4 +366,345 @@ export async function removeTagFromPost(postId: string, tagId: string) {
 				eq(contentResourceTagTable.tagId, tagId),
 			),
 		)
+}
+
+export class PostCreationError extends Error {
+	constructor(
+		message: string,
+		public readonly cause?: unknown,
+		public readonly context?: Record<string, unknown>,
+	) {
+		super(message)
+		this.name = 'PostCreationError'
+	}
+}
+
+export class DatabaseError extends PostCreationError {
+	constructor(
+		operation: string,
+		cause?: unknown,
+		context?: Record<string, unknown>,
+	) {
+		super(`Database operation failed: ${operation}`, cause, context)
+		this.name = 'DatabaseError'
+	}
+}
+
+const NewPostInputSchema = z.object({
+	title: z.string().min(1, 'Title is required'),
+	videoResourceId: z.string().optional(),
+	postType: z.enum([
+		'lesson',
+		'podcast',
+		'tip',
+		'course',
+		'playlist',
+		'article',
+	]),
+	createdById: z.string(),
+})
+
+export type NewPostInput = z.infer<typeof NewPostInputSchema>
+
+export async function writeNewPostToDatabase(
+	input: NewPostInput,
+): Promise<Post> {
+	try {
+		const validatedInput = NewPostInputSchema.parse(input)
+		const { title, videoResourceId, postType, createdById } = validatedInput
+
+		const postGuid = guid()
+		const newPostId = `post_${postGuid}`
+
+		// Step 1: Get video resource if needed
+		let videoResource = null
+		if (videoResourceId) {
+			videoResource =
+				await courseBuilderAdapter.getVideoResource(videoResourceId)
+		}
+
+		try {
+			// Step 3: Create the core post
+			const post = await createCorePost({
+				newPostId,
+				title,
+				postGuid,
+				postType,
+				createdById,
+			})
+
+			// Step 4: Handle contributions
+			await handleContributions({
+				createdById,
+				postId: post.id,
+				postGuid,
+			})
+
+			// Step 6: Create version
+			await createNewPostVersion(post)
+
+			return post
+		} catch (error) {
+			if (error instanceof PostCreationError) {
+				throw error
+			}
+
+			throw new PostCreationError('Failed to create post', error, {
+				input: validatedInput,
+			})
+		}
+	} catch (error) {
+		if (error instanceof z.ZodError) {
+			throw new PostCreationError('Invalid input for post creation', error, {
+				input,
+			})
+		}
+		throw error
+	}
+}
+
+async function createCorePost({
+	newPostId,
+	title,
+	postGuid,
+	postType,
+	createdById,
+}: {
+	newPostId: string
+	title: string
+	postGuid: string
+	postType: string
+	createdById: string
+}): Promise<Post> {
+	try {
+		await db.insert(contentResource).values({
+			id: newPostId,
+			type: 'post',
+			createdById,
+			fields: {
+				title,
+				state: 'draft',
+				visibility: 'public',
+				slug: `${slugify(title)}~${postGuid}`,
+				postType,
+				access: 'pro',
+			},
+		})
+
+		const post = await getPost(newPostId)
+
+		if (!post) {
+			throw new Error('Post not found after creation')
+		}
+
+		return post
+	} catch (error) {
+		throw new DatabaseError('create core post', error, { newPostId, title })
+	}
+}
+
+async function handleContributions({
+	createdById,
+	postId,
+	postGuid,
+}: {
+	createdById: string
+	postId: string
+	postGuid: string
+}) {
+	try {
+		const contributionType = await db.query.contributionTypes.findFirst({
+			where: eq(contributionTypes.slug, 'author'),
+		})
+
+		if (contributionType) {
+			await db.insert(contentContributions).values({
+				id: `cc-${postGuid}`,
+				userId: createdById,
+				contentId: postId,
+				contributionTypeId: contributionType.id,
+			})
+		}
+	} catch (error) {
+		throw new DatabaseError('handle contributions', error, {
+			createdById,
+			postId,
+		})
+	}
+}
+
+export async function createNewPostVersion(
+	post: Post | null,
+	createdById?: string,
+) {
+	if (!post) return null
+	const contentHash = generateContentHash(post)
+	const versionId = `version~${contentHash}`
+
+	// Check if this version already exists
+	const existingVersion = await db.query.contentResourceVersion.findFirst({
+		where: eq(contentResourceVersionTable.id, versionId),
+	})
+
+	if (existingVersion) {
+		// If this exact version already exists, just update the current version pointer
+		await db
+			.update(contentResource)
+			.set({ currentVersionId: versionId })
+			.where(eq(contentResource.id, post.id))
+		return post
+	}
+
+	// If it's a new version, create it
+	await db.transaction(async (trx) => {
+		await trx.insert(contentResourceVersionTable).values({
+			id: versionId,
+			resourceId: post.id,
+			parentVersionId: post.currentVersionId,
+			versionNumber: (await getLatestVersionNumber(post.id)) + 1,
+			fields: {
+				...post.fields,
+			},
+			createdAt: new Date(),
+			createdById: createdById ? createdById : post.createdById,
+		})
+
+		post.currentVersionId = versionId
+
+		await trx
+			.update(contentResource)
+			.set({ currentVersionId: versionId })
+			.where(eq(contentResource.id, post.id))
+	})
+	return post
+}
+
+export async function getLatestVersionNumber(postId: string): Promise<number> {
+	const latestVersion = await db.query.contentResourceVersion.findFirst({
+		where: eq(contentResourceVersionTable.resourceId, postId),
+		orderBy: desc(contentResourceVersionTable.versionNumber),
+	})
+	return latestVersion ? latestVersion.versionNumber : 0
+}
+
+export function updatePostSlug(currentPost: Post, newTitle: string): string {
+	if (newTitle !== currentPost.fields.title) {
+		const splitSlug = currentPost?.fields.slug.split('~') || ['', guid()]
+		return `${slugify(newTitle)}~${splitSlug[1] || guid()}`
+	}
+	return currentPost.fields.slug
+}
+
+export function generateContentHash(post: Post): string {
+	const content = JSON.stringify({
+		title: post.fields.title,
+		body: post.fields.body,
+		description: post.fields.description,
+		slug: post.fields.slug,
+		// Add any other fields that should be considered for content changes
+	})
+	return crypto.createHash('sha256').update(content).digest('hex')
+}
+
+export async function writePostUpdateToDatabase(input: {
+	currentPost?: Post
+	postUpdate: PostUpdate
+	action: PostAction
+	updatedById: string
+}) {
+	const {
+		currentPost = await getPost(input.postUpdate.id),
+		postUpdate,
+		action = 'save',
+		updatedById,
+	} = input
+
+	if (!currentPost) {
+		throw new Error(`Post with id ${input.postUpdate.id} not found.`)
+	}
+
+	if (!postUpdate.fields.title) {
+		throw new Error('Title is required')
+	}
+
+	let postSlug = updatePostSlug(currentPost, postUpdate.fields.title)
+
+	const postGuid = currentPost?.fields.slug.split('~')[1] || guid()
+
+	if (postUpdate.fields.title !== currentPost.fields.title) {
+		postSlug = `${slugify(postUpdate.fields.title ?? '')}~${postGuid}`
+	}
+
+	const duration = await getVideoDuration(currentPost.resources)
+	const timeToRead = Math.floor(
+		readingTime(currentPost.fields.body ?? '').time / 1000,
+	)
+
+	const videoResourceId =
+		postUpdate.videoResourceId ??
+		currentPost.resources?.find(
+			(resource) => resource.resource.type === 'videoResource',
+		)?.resourceId
+
+	const videoResource = videoResourceId
+		? await courseBuilderAdapter.getVideoResource(videoResourceId)
+		: null
+
+	await courseBuilderAdapter.updateContentResourceFields({
+		id: currentPost.id,
+		fields: {
+			...currentPost.fields,
+			...postUpdate.fields,
+			duration,
+			timeToRead,
+			slug: postSlug,
+		},
+	})
+
+	const updatedPost = await getPost(currentPost.id)
+
+	if (!updatedPost) {
+		throw new Error(`Post with id ${currentPost.id} not found.`)
+	}
+
+	const newContentHash = generateContentHash(updatedPost)
+
+	const currentContentHash = currentPost.currentVersionId?.split('~')[1]
+
+	if (newContentHash !== currentContentHash) {
+		await createNewPostVersion(updatedPost, updatedById)
+	}
+
+	await upsertPostToTypeSense(updatedPost, action)
+
+	return updatedPost
+}
+
+export async function getVideoDuration(
+	resources: Post['resources'],
+): Promise<number> {
+	const videoResource = resources?.find(
+		(resource) => resource.resource.type === 'videoResource',
+	)
+	if (videoResource) {
+		const muxAsset = await getMuxAsset(videoResource.resource.fields.muxAssetId)
+		return muxAsset?.duration ? Math.floor(muxAsset.duration) : 0
+	}
+	return 0
+}
+
+export async function deletePostFromDatabase(id: string) {
+	const post = PostSchema.nullish().parse(await getPost(id))
+
+	if (!post) {
+		throw new Error(`Post with id ${id} not found.`)
+	}
+
+	await db
+		.delete(contentResourceResource)
+		.where(eq(contentResourceResource.resourceOfId, id))
+
+	await db.delete(contentResource).where(eq(contentResource.id, id))
+
+	return true
 }

--- a/apps/ai-hero/src/lib/posts-query.ts
+++ b/apps/ai-hero/src/lib/posts-query.ts
@@ -156,7 +156,7 @@ export async function createPost(input: NewPost) {
 		fields: {
 			title: input.title,
 			state: 'draft',
-			visibility: 'unlisted',
+			visibility: 'public',
 			slug: slugify(`${input.title}~${postGuid}`),
 		},
 	}

--- a/apps/ai-hero/src/lib/posts.ts
+++ b/apps/ai-hero/src/lib/posts.ts
@@ -2,7 +2,17 @@ import { z } from 'zod'
 
 import { ContentResourceSchema } from '@coursebuilder/core/schemas/content-resource-schema'
 
-import { TagFieldsSchema, TagSchema } from './tags'
+export const POST_TYPES_WITH_VIDEO = ['lesson', 'podcast', 'tip']
+
+export const PostTypeSchema = z.union([
+	z.literal('article'),
+	z.literal('lesson'),
+	z.literal('podcast'),
+	z.literal('tip'),
+	z.literal('course'),
+])
+
+export type PostType = z.infer<typeof PostTypeSchema>
 
 export const PostActionSchema = z.union([
 	z.literal('publish'),

--- a/apps/ai-hero/src/lib/posts.ts
+++ b/apps/ai-hero/src/lib/posts.ts
@@ -16,6 +16,7 @@ export type PostAction = z.infer<typeof PostActionSchema>
 export const NewPostSchema = z.object({
 	title: z.string().min(2).max(90),
 	videoResourceId: z.string().min(4, 'Please upload a video'),
+	postType: z.enum(['lesson', 'podcast', 'tip']),
 })
 export type NewPost = z.infer<typeof NewPostSchema>
 
@@ -63,6 +64,7 @@ export const PostUpdateSchema = z.object({
 		visibility: PostVisibilitySchema.default('unlisted'),
 		github: z.string().nullish(),
 	}),
+	videoResourceId: z.string().optional().nullable(),
 })
 
 export type PostUpdate = z.infer<typeof PostUpdateSchema>

--- a/apps/ai-hero/src/lib/posts.ts
+++ b/apps/ai-hero/src/lib/posts.ts
@@ -68,3 +68,19 @@ export const PostUpdateSchema = z.object({
 })
 
 export type PostUpdate = z.infer<typeof PostUpdateSchema>
+
+export const NewPostInputSchema = z.object({
+	title: z.string().min(1, 'Title is required'),
+	videoResourceId: z.string().optional(),
+	postType: z.enum([
+		'lesson',
+		'podcast',
+		'tip',
+		'course',
+		'playlist',
+		'article',
+	]),
+	createdById: z.string(),
+})
+
+export type NewPostInput = z.infer<typeof NewPostInputSchema>

--- a/apps/ai-hero/src/lib/progress.ts
+++ b/apps/ai-hero/src/lib/progress.ts
@@ -144,7 +144,7 @@ export async function getModuleProgressForUser(
 	moduleIdOrSlug: string,
 ): Promise<ModuleProgress | null> {
 	const { session } = await getServerAuthSession()
-	if (session.user) {
+	if (session?.user) {
 		const moduleProgress = await courseBuilderAdapter.getModuleProgressForUser(
 			session.user.id,
 			moduleIdOrSlug,

--- a/apps/ai-hero/src/server/ability-for-request.ts
+++ b/apps/ai-hero/src/server/ability-for-request.ts
@@ -1,0 +1,48 @@
+import { NextRequest } from 'next/server'
+import { getAbility, UserSchema } from '@/ability'
+import { db } from '@/db'
+import { deviceAccessToken } from '@/db/schema'
+import { eq } from 'drizzle-orm'
+
+export async function getUserAbilityForRequest(request: NextRequest) {
+	const authToken = request.headers.get('Authorization')?.split(' ')[1]
+
+	if (!authToken) {
+		return { user: null, ability: getAbility() }
+	}
+
+	const deviceToken = await db.query.deviceAccessToken.findFirst({
+		where: eq(deviceAccessToken.token, authToken),
+		with: {
+			verifiedBy: {
+				with: {
+					roles: {
+						with: {
+							role: true,
+						},
+					},
+				},
+			},
+		},
+	})
+
+	if (!deviceToken) {
+		return { user: null, ability: getAbility() }
+	}
+
+	const userParsed = UserSchema.safeParse({
+		...deviceToken.verifiedBy,
+		roles: deviceToken.verifiedBy.roles.map((role) => role.role),
+	})
+
+	if (!userParsed.success) {
+		return { user: null, ability: getAbility() }
+	}
+
+	const user = userParsed.data
+	const ability = getAbility({ user })
+
+	console.log({ user })
+
+	return { user, ability }
+}

--- a/apps/ai-hero/src/server/auth.ts
+++ b/apps/ai-hero/src/server/auth.ts
@@ -1,5 +1,5 @@
 import { cookies, headers } from 'next/headers'
-import { getAbility } from '@/ability'
+import { getAbility, UserSchema } from '@/ability'
 import { emailProvider } from '@/coursebuilder/email-provider'
 import { courseBuilderAdapter, db } from '@/db'
 import { accounts } from '@/db/schema'
@@ -16,7 +16,7 @@ import NextAuth, { type DefaultSession, type NextAuthConfig } from 'next-auth'
 
 import { userSchema } from '@coursebuilder/core/schemas'
 
-type Role = 'admin' | 'user'
+type Role = 'admin' | 'user' | string
 
 /**
  * Module augmentation for `next-auth` types. Allows us to add custom properties to the `session`
@@ -290,9 +290,12 @@ export const {
 export const getServerAuthSession = async () => {
 	const session = await auth()
 	const user = userSchema.optional().nullable().parse(session?.user)
-	const ability = getAbility({ user: session?.user })
+	const parsedUser = UserSchema.nullish().parse(session?.user)
+	const ability = getAbility({ user: parsedUser || undefined })
 
-	return { session: { ...session, user }, ability }
+	console.log('pfft', { session, parsedUser })
+
+	return { session: session ? { ...session, user } : null, ability }
 }
 
 export type Provider = {

--- a/apps/ai-hero/src/trpc/api/root.ts
+++ b/apps/ai-hero/src/trpc/api/root.ts
@@ -1,6 +1,7 @@
 import { abilityRouter } from '@/trpc/api/routers/ability'
 import { certificateRouter } from '@/trpc/api/routers/certificate'
 import { contentResourceRouter } from '@/trpc/api/routers/contentResources'
+import { deviceVerificationRouter } from '@/trpc/api/routers/device-verification'
 import { eventsRouter } from '@/trpc/api/routers/events'
 import { imageResourceRouter } from '@/trpc/api/routers/imageResource'
 import { lessonsRouter } from '@/trpc/api/routers/lessons'
@@ -26,6 +27,7 @@ export const appRouter = createTRPCRouter({
 	progress: progressRouter,
 	lessons: lessonsRouter,
 	certificate: certificateRouter,
+	deviceVerification: deviceVerificationRouter,
 })
 
 // export type definition of API

--- a/apps/ai-hero/src/trpc/api/routers/device-verification.ts
+++ b/apps/ai-hero/src/trpc/api/routers/device-verification.ts
@@ -1,0 +1,62 @@
+import { db } from '@/db'
+import { deviceVerifications } from '@/db/schema'
+import { getServerAuthSession } from '@/server/auth'
+import { isAfter } from 'date-fns'
+import { eq } from 'drizzle-orm'
+import { z } from 'zod'
+
+import { createTRPCRouter, publicProcedure } from '../trpc'
+
+export const deviceVerificationRouter = createTRPCRouter({
+	verify: publicProcedure
+		.input(
+			z.object({
+				userCode: z.string(),
+			}),
+		)
+		.mutation(async ({ ctx, input }) => {
+			const { session } = await getServerAuthSession()
+
+			console.log({ session })
+
+			if (session) {
+				const deviceVerification = await db.query.deviceVerifications.findFirst(
+					{
+						where: eq(deviceVerifications.userCode, input.userCode),
+					},
+				)
+
+				console.log({ deviceVerification })
+
+				if (deviceVerification) {
+					if (deviceVerification.verifiedAt) {
+						return { status: 'already-verified' }
+					}
+
+					if (isAfter(new Date(), deviceVerification.expires)) {
+						return { status: 'code-expired' }
+					}
+
+					if (!session.user) {
+						return { status: 'login-required' }
+					}
+
+					await db
+						.update(deviceVerifications)
+						.set({
+							verifiedAt: new Date(),
+							verifiedByUserId: session.user.id,
+						})
+						.where(
+							eq(deviceVerifications.deviceCode, deviceVerification.deviceCode),
+						)
+
+					return { status: 'device-verified' }
+				} else {
+					return { status: 'no-verification-found' }
+				}
+			} else {
+				return { status: 'login-required' }
+			}
+		}),
+})

--- a/apps/ai-hero/src/uploadthing/core.ts
+++ b/apps/ai-hero/src/uploadthing/core.ts
@@ -19,7 +19,7 @@ export const ourFileRouter = {
 
 			console.log({ input })
 
-			if (!session.user || !ability.can('create', 'Content')) {
+			if (!session?.user || !ability.can('create', 'Content')) {
 				throw new Error('Unauthorized')
 			}
 

--- a/apps/ai-hero/src/video-uploader/get-signed-s3-url.ts
+++ b/apps/ai-hero/src/video-uploader/get-signed-s3-url.ts
@@ -1,0 +1,34 @@
+import { PutObjectCommand, S3Client, S3ClientConfig } from '@aws-sdk/client-s3'
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
+import { v4 as uuidv4 } from 'uuid'
+
+const options: S3ClientConfig = {
+	region: process.env.AWS_VIDEO_UPLOAD_REGION,
+	credentials: {
+		accessKeyId: process.env.AWS_VIDEO_UPLOAD_ACCESS_KEY_ID!,
+		secretAccessKey: process.env.AWS_VIDEO_UPLOAD_SECRET_ACCESS_KEY!,
+	},
+}
+
+const client = new S3Client(options)
+
+export async function getSignedUrlForVideoFile(options: { filename: string }) {
+	const filename = `${uuidv4()}/${options.filename}`
+	const Key = `${
+		process.env.AWS_VIDEO_UPLOAD_FOLDER || 'partner-uploads'
+	}/${filename}`
+	const Bucket = process.env.AWS_VIDEO_UPLOAD_BUCKET
+	const expiresIn = 3600
+
+	const command = new PutObjectCommand({ Bucket, Key })
+	const signedUrl = await getSignedUrl(client, command, { expiresIn })
+
+	if (signedUrl) {
+		return {
+			signedUrl,
+			filename,
+			objectName: options.filename,
+			publicUrl: signedUrl.split('?').shift(),
+		}
+	}
+}

--- a/apps/ai-hero/src/video-uploader/get-unique-filename.ts
+++ b/apps/ai-hero/src/video-uploader/get-unique-filename.ts
@@ -1,0 +1,22 @@
+import uuid from 'shortid'
+
+function fileExtension(
+	filename: string,
+	opts: { preserveCase?: boolean } = {},
+): string {
+	if (!opts) opts = {}
+	if (!filename) return ''
+	var ext = (/[^./\\]*$/.exec(filename) || [''])[0]
+	return opts.preserveCase ? ext : ext.toLowerCase()
+}
+
+export const getUniqueFilename = (fullFilename: string) => {
+	// filename with no extension
+	const filename = fullFilename.replace(/\.[^/.]+$/, '')
+	// remove stuff s3 hates
+	const scrubbed = `${filename}-${uuid.generate()}`
+		.replace(/[^\w\d_\-.]+/gi, '')
+		.toLowerCase()
+	// rebuild it as a fresh new thing
+	return `${scrubbed}.${fileExtension(fullFilename)}`
+}

--- a/apps/ai-hero/src/video-uploader/upload-to-s3.ts
+++ b/apps/ai-hero/src/video-uploader/upload-to-s3.ts
@@ -1,0 +1,53 @@
+import axios from 'axios'
+
+import { getUniqueFilename } from './get-unique-filename'
+
+export async function uploadToS3({
+	fileType,
+	fileContents,
+	onUploadProgress = () => {},
+	signingUrl,
+}: {
+	fileType: string
+	fileContents: File
+	onUploadProgress: (progressEvent: { loaded: number; total?: number }) => void
+	signingUrl: string
+}) {
+	const presignedPostUrl = await getPresignedPostUrl({
+		fileType,
+		fileName: fileContents.name,
+		signingUrl,
+	})
+
+	await axios.put(presignedPostUrl.signedUrl, fileContents, {
+		headers: { 'Content-Type': 'application/octet-stream' },
+		onUploadProgress,
+	})
+
+	return presignedPostUrl.publicUrl
+}
+
+type PresignedPostUrlResponse = {
+	signedUrl: string
+	publicUrl: string
+	filename: string
+	objectName: string
+}
+
+async function getPresignedPostUrl({
+	fileType,
+	fileName,
+	signingUrl,
+}: {
+	fileType: string
+	fileName: string
+	signingUrl: string
+}) {
+	const { data: presignedPostUrl } = await axios.get<PresignedPostUrlResponse>(
+		`${signingUrl}?contentType=${fileType}&objectName=${getUniqueFilename(
+			fileName,
+		)}`,
+	)
+
+	return presignedPostUrl
+}

--- a/apps/ai-hero/src/video-uploader/use-file-change.ts
+++ b/apps/ai-hero/src/video-uploader/use-file-change.ts
@@ -1,0 +1,119 @@
+import { useReducer } from 'react'
+
+const initialFileState = {
+	fileError: null,
+	fileName: null,
+	fileSize: null,
+	fileType: null,
+	fileContents: null,
+}
+
+function bytesToMb(bytes: number) {
+	const mb = bytes / 1000000
+
+	return mb
+}
+
+export function useFileChange() {
+	const [
+		{ fileError, fileContents, fileName, fileSize, fileType },
+		fileDispatch,
+	] = useReducer(fileChangeReducer, initialFileState)
+
+	const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+		const fileObj = event.target.files && event.target.files[0]
+		if (!fileObj) {
+			return
+		}
+
+		console.log('fileObj is', fileObj)
+
+		const [type] = fileObj.type.split('/')
+		if (!type || type !== 'video') {
+			fileDispatch({
+				type: 'FILE_CHANGE_FAILURE',
+				fileError: 'You can only upload image files.',
+			})
+			return
+		}
+
+		// if (fileObj.size > 10000000000) {
+		//   fileDispatch({
+		//     type: 'FILE_CHANGE_FAILURE',
+		//     fileError: `File is too large, file size is ${bytesToMb(
+		//       fileObj.size,
+		//     ).toFixed(2)} MB, maximum allowed size - 1 MB.`,
+		//   })
+		//   return
+		// }
+
+		// eslint-disable-next-line no-param-reassign
+		event.target.value = ''
+
+		fileDispatch({
+			type: 'FILE_CHANGE_SUCCESS',
+			fileName: fileObj.name,
+			fileSize: fileObj.size,
+			fileType: fileObj.type,
+			fileContents: fileObj,
+		})
+	}
+
+	return {
+		fileError,
+		fileContents,
+		fileName,
+		fileType,
+		fileSize,
+		handleFileChange,
+		fileDispatch,
+	}
+}
+
+type FileState = {
+	fileError: string | null
+	fileName: string | null
+	fileSize: number | null
+	fileType: string | null
+	fileContents: File | null
+}
+
+type FileChangeAction =
+	| {
+			type: 'FILE_CHANGE_SUCCESS'
+			fileName: string
+			fileSize: number
+			fileType: string
+			fileContents: File
+	  }
+	| { type: 'FILE_CHANGE_FAILURE'; fileError: string }
+	| { type: 'RESET_FILE_STATE' }
+
+export function fileChangeReducer(
+	_state: FileState,
+	action: FileChangeAction,
+): FileState {
+	switch (action.type) {
+		case 'FILE_CHANGE_SUCCESS': {
+			return {
+				fileError: null,
+				fileName: action.fileName,
+				fileSize: action.fileSize,
+				fileType: action.fileType,
+				fileContents: action.fileContents,
+			}
+		}
+		case 'FILE_CHANGE_FAILURE': {
+			return {
+				...initialFileState,
+				fileError: action.fileError,
+			}
+		}
+		case 'RESET_FILE_STATE': {
+			return initialFileState
+		}
+		default: {
+			throw new Error(`Unsupported action type: ${JSON.stringify(action)}`)
+		}
+	}
+}

--- a/apps/course-builder-video-blog/src/app/(user)/activate/_components/verifiy.tsx
+++ b/apps/course-builder-video-blog/src/app/(user)/activate/_components/verifiy.tsx
@@ -18,7 +18,7 @@ export default function Verify({ userCode }: { userCode: string }) {
 				<Fingerprint animate={animate} />
 				<h1 className="text-2xl font-bold sm:text-3xl">Device Confirmation</h1>
 				<p className="py-4 text-gray-600 dark:text-gray-400">
-					Please confirm this is the code displayed in your Workshop App
+					Please confirm this is the code displayed in your app
 				</p>
 				<div className="w-full rounded-md border px-5 py-3 text-lg font-semibold dark:border-transparent dark:bg-black/75">
 					{userCode}

--- a/apps/egghead/package.json
+++ b/apps/egghead/package.json
@@ -72,6 +72,7 @@
 		"date-fns": "^2.30.0",
 		"date-fns-tz": "^2.0.1",
 		"drizzle-orm": "0.36.0",
+		"egghead": "link:",
 		"framer-motion": "^12.0.0-alpha.1",
 		"human-readable-ids": "^1.0.4",
 		"inngest": "^3.22.5",

--- a/apps/egghead/package.json
+++ b/apps/egghead/package.json
@@ -72,7 +72,6 @@
 		"date-fns": "^2.30.0",
 		"date-fns-tz": "^2.0.1",
 		"drizzle-orm": "0.36.0",
-		"egghead": "link:",
 		"framer-motion": "^12.0.0-alpha.1",
 		"human-readable-ids": "^1.0.4",
 		"inngest": "^3.22.5",

--- a/apps/egghead/src/lib/posts.ts
+++ b/apps/egghead/src/lib/posts.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto'
+import crypto from 'node:crypto'
 import { guid } from '@/utils/guid'
 import slugify from '@sindresorhus/slugify'
 import { z } from 'zod'

--- a/apps/egghead/src/lib/posts.ts
+++ b/apps/egghead/src/lib/posts.ts
@@ -1,4 +1,4 @@
-import crypto from 'node:crypto'
+import crypto from 'crypto'
 import { guid } from '@/utils/guid'
 import slugify from '@sindresorhus/slugify'
 import { z } from 'zod'

--- a/packages/core/src/schemas/user-schema.ts
+++ b/packages/core/src/schemas/user-schema.ts
@@ -5,9 +5,9 @@ export const userSchema = z.object({
 	name: z.string().max(255).optional().nullable(),
 	role: z.enum(['user', 'admin']).default('user'),
 	email: z.string().max(255).email(),
-	emailVerified: z.coerce.date().nullable(),
+	emailVerified: z.coerce.date().nullish(),
 	image: z.string().max(255).optional().nullable(),
-	createdAt: z.coerce.date().nullable(),
+	createdAt: z.coerce.date().nullish(),
 	memberships: z
 		.array(
 			z.object({
@@ -15,7 +15,7 @@ export const userSchema = z.object({
 				organizationId: z.string(),
 			}),
 		)
-		.optional()
+		.nullish()
 		.default([]),
 	roles: z
 		.array(

--- a/packages/core/src/schemas/user-schema.ts
+++ b/packages/core/src/schemas/user-schema.ts
@@ -24,6 +24,9 @@ export const userSchema = z.object({
 				name: z.string(),
 				description: z.string().nullable(),
 				active: z.boolean(),
+				createdAt: z.coerce.date().nullish(),
+				updatedAt: z.coerce.date().nullish(),
+				deletedAt: z.coerce.date().nullish(),
 			}),
 		)
 		.optional()
@@ -36,6 +39,9 @@ export const userSchema = z.object({
 				name: z.string(),
 				description: z.string().nullable(),
 				active: z.boolean(),
+				createdAt: z.coerce.date().nullish(),
+				updatedAt: z.coerce.date().nullish(),
+				deletedAt: z.coerce.date().nullish(),
 			}),
 		)
 		.optional()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2317,9 +2317,6 @@ importers:
       drizzle-orm:
         specifier: 0.36.0
         version: 0.36.0(@planetscale/database@1.19.0)(@types/pg@8.11.8)(mysql2@3.9.2)(pg@8.12.0)(react@19.0.0-rc-02c0e824-20241028)(types-react@19.0.0-rc.1)
-      egghead:
-        specifier: 'link:'
-        version: 'link:'
       framer-motion:
         specifier: ^12.0.0-alpha.1
         version: 12.0.0-alpha.1(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
@@ -6240,7 +6237,7 @@ importers:
         version: 1.0.7
       next:
         specifier: 15.0.3
-        version: 15.0.3(@babel/core@7.24.0)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
+        version: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
       react:
         specifier: 19.0.0-rc-02c0e824-20241028
         version: 19.0.0-rc-02c0e824-20241028
@@ -6437,7 +6434,7 @@ importers:
         version: 19.0.0-rc-02c0e824-20241028
       react-email:
         specifier: 2.1.1
-        version: 2.1.1(@babel/core@7.24.0)(eslint@8.57.1)
+        version: 2.1.1(@babel/core@7.26.0)(eslint@8.57.1)
       tsup:
         specifier: 8.0.2
         version: 8.0.2(postcss@8.4.35)(typescript@5.4.5)
@@ -6456,7 +6453,7 @@ importers:
         version: 0.37.2(nodemailer@6.9.11)
       next:
         specifier: 15.0.3
-        version: 15.0.3(@babel/core@7.24.0)(react-dom@19.0.0-rc-66855b96-20241106)(react@19.0.0-rc-02c0e824-20241028)
+        version: 15.0.3(@babel/core@7.26.0)(react-dom@19.0.0-rc-66855b96-20241106)(react@19.0.0-rc-02c0e824-20241028)
       next-auth:
         specifier: 5.0.0-beta.25
         version: 5.0.0-beta.25(next@15.0.3)(react@19.0.0-rc-02c0e824-20241028)
@@ -31322,7 +31319,7 @@ packages:
       react-dom: 19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028)
     dev: false
 
-  /next@14.1.0(@babel/core@7.24.0)(react-dom@18.3.1)(react@18.3.1):
+  /next@14.1.0(@babel/core@7.26.0)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-wlzrsbfeSU48YQBjZhDzOwhWhGsy+uQycR8bHAOt1LY1bn3zZEcDyHQOEoN3aWzQ8LHCAJ1nqrWCc9XF2+O45Q==}
     engines: {node: '>=18.17.0'}
     hasBin: true
@@ -31345,7 +31342,7 @@ packages:
       postcss: 8.4.31
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      styled-jsx: 5.1.1(@babel/core@7.24.0)(react@18.3.1)
+      styled-jsx: 5.1.1(@babel/core@7.26.0)(react@18.3.1)
     optionalDependencies:
       '@next/swc-darwin-arm64': 14.1.0
       '@next/swc-darwin-x64': 14.1.0
@@ -31405,51 +31402,6 @@ packages:
       - '@babel/core'
       - babel-plugin-macros
 
-  /next@15.0.3(@babel/core@7.24.0)(react-dom@19.0.0-rc-66855b96-20241106)(react@19.0.0-rc-02c0e824-20241028):
-    resolution: {integrity: sha512-ontCbCRKJUIoivAdGB34yCaOcPgYXr9AAkV/IwqFfWWTXEPUgLYkSkqBhIk9KK7gGmgjc64B+RdoeIDM13Irnw==}
-    engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@opentelemetry/api': ^1.1.0
-      '@playwright/test': ^1.41.2
-      babel-plugin-react-compiler: '*'
-      react: ^18.2.0 || 19.0.0-rc-66855b96-20241106
-      react-dom: ^18.2.0 || 19.0.0-rc-66855b96-20241106
-      sass: ^1.3.0
-    peerDependenciesMeta:
-      '@opentelemetry/api':
-        optional: true
-      '@playwright/test':
-        optional: true
-      babel-plugin-react-compiler:
-        optional: true
-      sass:
-        optional: true
-    dependencies:
-      '@next/env': 15.0.3
-      '@swc/counter': 0.1.3
-      '@swc/helpers': 0.5.13
-      busboy: 1.6.0
-      caniuse-lite: 1.0.30001676
-      postcss: 8.4.31
-      react: 19.0.0-rc-02c0e824-20241028
-      react-dom: 19.0.0-rc-66855b96-20241106(react@19.0.0-rc-02c0e824-20241028)
-      styled-jsx: 5.1.6(@babel/core@7.24.0)(react@19.0.0-rc-02c0e824-20241028)
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 15.0.3
-      '@next/swc-darwin-x64': 15.0.3
-      '@next/swc-linux-arm64-gnu': 15.0.3
-      '@next/swc-linux-arm64-musl': 15.0.3
-      '@next/swc-linux-x64-gnu': 15.0.3
-      '@next/swc-linux-x64-musl': 15.0.3
-      '@next/swc-win32-arm64-msvc': 15.0.3
-      '@next/swc-win32-x64-msvc': 15.0.3
-      sharp: 0.33.5
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
-    dev: true
-
   /next@15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028):
     resolution: {integrity: sha512-ontCbCRKJUIoivAdGB34yCaOcPgYXr9AAkV/IwqFfWWTXEPUgLYkSkqBhIk9KK7gGmgjc64B+RdoeIDM13Irnw==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
@@ -31495,6 +31447,51 @@ packages:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
+
+  /next@15.0.3(@babel/core@7.26.0)(react-dom@19.0.0-rc-66855b96-20241106)(react@19.0.0-rc-02c0e824-20241028):
+    resolution: {integrity: sha512-ontCbCRKJUIoivAdGB34yCaOcPgYXr9AAkV/IwqFfWWTXEPUgLYkSkqBhIk9KK7gGmgjc64B+RdoeIDM13Irnw==}
+    engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.41.2
+      babel-plugin-react-compiler: '*'
+      react: ^18.2.0 || 19.0.0-rc-66855b96-20241106
+      react-dom: ^18.2.0 || 19.0.0-rc-66855b96-20241106
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+      sass:
+        optional: true
+    dependencies:
+      '@next/env': 15.0.3
+      '@swc/counter': 0.1.3
+      '@swc/helpers': 0.5.13
+      busboy: 1.6.0
+      caniuse-lite: 1.0.30001676
+      postcss: 8.4.31
+      react: 19.0.0-rc-02c0e824-20241028
+      react-dom: 19.0.0-rc-66855b96-20241106(react@19.0.0-rc-02c0e824-20241028)
+      styled-jsx: 5.1.6(@babel/core@7.26.0)(react@19.0.0-rc-02c0e824-20241028)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 15.0.3
+      '@next/swc-darwin-x64': 15.0.3
+      '@next/swc-linux-arm64-gnu': 15.0.3
+      '@next/swc-linux-arm64-musl': 15.0.3
+      '@next/swc-linux-x64-gnu': 15.0.3
+      '@next/swc-linux-x64-musl': 15.0.3
+      '@next/swc-win32-arm64-msvc': 15.0.3
+      '@next/swc-win32-x64-msvc': 15.0.3
+      sharp: 0.33.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+    dev: true
 
   /nlcst-to-string@3.1.1:
     resolution: {integrity: sha512-63mVyqaqt0cmn2VcI2aH6kxe1rLAmSROqHMA0i4qqg1tidkfExgpb0FGMikMCn86mw5dFtBtEANfmSSK7TjNHw==}
@@ -33491,7 +33488,7 @@ packages:
       scheduler: 0.25.0-rc-66855b96-20241106
     dev: true
 
-  /react-email@2.1.1(@babel/core@7.24.0)(eslint@8.57.1):
+  /react-email@2.1.1(@babel/core@7.26.0)(eslint@8.57.1):
     resolution: {integrity: sha512-09oMVl/jN0/Re0bT0sEqYjyyFSCN/Tg0YmzjC9wfYpnMx02Apk40XXitySDfUBMR9EgTdr6T4lYknACqiLK3mg==}
     engines: {node: '>=18.0.0'}
     hasBin: true
@@ -33523,7 +33520,7 @@ packages:
       glob: 10.3.4
       log-symbols: 4.1.0
       mime-types: 2.1.35
-      next: 14.1.0(@babel/core@7.24.0)(react-dom@18.3.1)(react@18.3.1)
+      next: 14.1.0(@babel/core@7.26.0)(react-dom@18.3.1)(react@18.3.1)
       normalize-path: 3.0.0
       ora: 5.4.1
       postcss: 8.4.35
@@ -35991,7 +35988,7 @@ packages:
       - '@babel/core'
     dev: false
 
-  /styled-jsx@5.1.1(@babel/core@7.24.0)(react@18.3.1):
+  /styled-jsx@5.1.1(@babel/core@7.26.0)(react@18.3.1):
     resolution: {integrity: sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==}
     engines: {node: '>= 12.0.0'}
     peerDependencies:
@@ -36004,7 +36001,7 @@ packages:
       babel-plugin-macros:
         optional: true
     dependencies:
-      '@babel/core': 7.24.0
+      '@babel/core': 7.26.0
       client-only: 0.0.1
       react: 18.3.1
     dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -386,6 +386,9 @@ importers:
       holy-loader:
         specifier: ^2.2.10
         version: 2.2.10(react@19.0.0-rc-02c0e824-20241028)
+      human-readable-ids:
+        specifier: ^1.0.4
+        version: 1.0.4
       i:
         specifier: ^0.3.7
         version: 0.3.7
@@ -6231,7 +6234,7 @@ importers:
         version: 1.0.7
       next:
         specifier: 15.0.3
-        version: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
+        version: 15.0.3(@babel/core@7.24.0)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)
       react:
         specifier: 19.0.0-rc-02c0e824-20241028
         version: 19.0.0-rc-02c0e824-20241028
@@ -6428,7 +6431,7 @@ importers:
         version: 19.0.0-rc-02c0e824-20241028
       react-email:
         specifier: 2.1.1
-        version: 2.1.1(@babel/core@7.26.0)(eslint@8.57.1)
+        version: 2.1.1(@babel/core@7.24.0)(eslint@8.57.1)
       tsup:
         specifier: 8.0.2
         version: 8.0.2(postcss@8.4.35)(typescript@5.4.5)
@@ -6447,7 +6450,7 @@ importers:
         version: 0.37.2(nodemailer@6.9.11)
       next:
         specifier: 15.0.3
-        version: 15.0.3(@babel/core@7.26.0)(react-dom@19.0.0-rc-66855b96-20241106)(react@19.0.0-rc-02c0e824-20241028)
+        version: 15.0.3(@babel/core@7.24.0)(react-dom@19.0.0-rc-66855b96-20241106)(react@19.0.0-rc-02c0e824-20241028)
       next-auth:
         specifier: 5.0.0-beta.25
         version: 5.0.0-beta.25(next@15.0.3)(react@19.0.0-rc-02c0e824-20241028)
@@ -27048,6 +27051,7 @@ packages:
       space-separated-tokens: 2.0.2
       stringify-entities: 4.0.3
       zwitch: 2.0.4
+    dev: false
 
   /hast-util-to-html@9.0.4:
     resolution: {integrity: sha512-wxQzXtdbhiwGAUKrnQJXlOPmHnEehzphwkK7aluUPQ+lEc1xefC8pblMgpp2w5ldBTEfveRIrADcrhGIWrlTDA==}
@@ -31312,7 +31316,7 @@ packages:
       react-dom: 19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028)
     dev: false
 
-  /next@14.1.0(@babel/core@7.26.0)(react-dom@18.3.1)(react@18.3.1):
+  /next@14.1.0(@babel/core@7.24.0)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-wlzrsbfeSU48YQBjZhDzOwhWhGsy+uQycR8bHAOt1LY1bn3zZEcDyHQOEoN3aWzQ8LHCAJ1nqrWCc9XF2+O45Q==}
     engines: {node: '>=18.17.0'}
     hasBin: true
@@ -31335,7 +31339,7 @@ packages:
       postcss: 8.4.31
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      styled-jsx: 5.1.1(@babel/core@7.26.0)(react@18.3.1)
+      styled-jsx: 5.1.1(@babel/core@7.24.0)(react@18.3.1)
     optionalDependencies:
       '@next/swc-darwin-arm64': 14.1.0
       '@next/swc-darwin-x64': 14.1.0
@@ -31395,6 +31399,51 @@ packages:
       - '@babel/core'
       - babel-plugin-macros
 
+  /next@15.0.3(@babel/core@7.24.0)(react-dom@19.0.0-rc-66855b96-20241106)(react@19.0.0-rc-02c0e824-20241028):
+    resolution: {integrity: sha512-ontCbCRKJUIoivAdGB34yCaOcPgYXr9AAkV/IwqFfWWTXEPUgLYkSkqBhIk9KK7gGmgjc64B+RdoeIDM13Irnw==}
+    engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.41.2
+      babel-plugin-react-compiler: '*'
+      react: ^18.2.0 || 19.0.0-rc-66855b96-20241106
+      react-dom: ^18.2.0 || 19.0.0-rc-66855b96-20241106
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+      sass:
+        optional: true
+    dependencies:
+      '@next/env': 15.0.3
+      '@swc/counter': 0.1.3
+      '@swc/helpers': 0.5.13
+      busboy: 1.6.0
+      caniuse-lite: 1.0.30001676
+      postcss: 8.4.31
+      react: 19.0.0-rc-02c0e824-20241028
+      react-dom: 19.0.0-rc-66855b96-20241106(react@19.0.0-rc-02c0e824-20241028)
+      styled-jsx: 5.1.6(@babel/core@7.24.0)(react@19.0.0-rc-02c0e824-20241028)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 15.0.3
+      '@next/swc-darwin-x64': 15.0.3
+      '@next/swc-linux-arm64-gnu': 15.0.3
+      '@next/swc-linux-arm64-musl': 15.0.3
+      '@next/swc-linux-x64-gnu': 15.0.3
+      '@next/swc-linux-x64-musl': 15.0.3
+      '@next/swc-win32-arm64-msvc': 15.0.3
+      '@next/swc-win32-x64-msvc': 15.0.3
+      sharp: 0.33.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+    dev: true
+
   /next@15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028):
     resolution: {integrity: sha512-ontCbCRKJUIoivAdGB34yCaOcPgYXr9AAkV/IwqFfWWTXEPUgLYkSkqBhIk9KK7gGmgjc64B+RdoeIDM13Irnw==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
@@ -31440,51 +31489,6 @@ packages:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
-
-  /next@15.0.3(@babel/core@7.26.0)(react-dom@19.0.0-rc-66855b96-20241106)(react@19.0.0-rc-02c0e824-20241028):
-    resolution: {integrity: sha512-ontCbCRKJUIoivAdGB34yCaOcPgYXr9AAkV/IwqFfWWTXEPUgLYkSkqBhIk9KK7gGmgjc64B+RdoeIDM13Irnw==}
-    engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@opentelemetry/api': ^1.1.0
-      '@playwright/test': ^1.41.2
-      babel-plugin-react-compiler: '*'
-      react: ^18.2.0 || 19.0.0-rc-66855b96-20241106
-      react-dom: ^18.2.0 || 19.0.0-rc-66855b96-20241106
-      sass: ^1.3.0
-    peerDependenciesMeta:
-      '@opentelemetry/api':
-        optional: true
-      '@playwright/test':
-        optional: true
-      babel-plugin-react-compiler:
-        optional: true
-      sass:
-        optional: true
-    dependencies:
-      '@next/env': 15.0.3
-      '@swc/counter': 0.1.3
-      '@swc/helpers': 0.5.13
-      busboy: 1.6.0
-      caniuse-lite: 1.0.30001676
-      postcss: 8.4.31
-      react: 19.0.0-rc-02c0e824-20241028
-      react-dom: 19.0.0-rc-66855b96-20241106(react@19.0.0-rc-02c0e824-20241028)
-      styled-jsx: 5.1.6(@babel/core@7.26.0)(react@19.0.0-rc-02c0e824-20241028)
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 15.0.3
-      '@next/swc-darwin-x64': 15.0.3
-      '@next/swc-linux-arm64-gnu': 15.0.3
-      '@next/swc-linux-arm64-musl': 15.0.3
-      '@next/swc-linux-x64-gnu': 15.0.3
-      '@next/swc-linux-x64-musl': 15.0.3
-      '@next/swc-win32-arm64-msvc': 15.0.3
-      '@next/swc-win32-x64-msvc': 15.0.3
-      sharp: 0.33.5
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
-    dev: true
 
   /nlcst-to-string@3.1.1:
     resolution: {integrity: sha512-63mVyqaqt0cmn2VcI2aH6kxe1rLAmSROqHMA0i4qqg1tidkfExgpb0FGMikMCn86mw5dFtBtEANfmSSK7TjNHw==}
@@ -33481,7 +33485,7 @@ packages:
       scheduler: 0.25.0-rc-66855b96-20241106
     dev: true
 
-  /react-email@2.1.1(@babel/core@7.26.0)(eslint@8.57.1):
+  /react-email@2.1.1(@babel/core@7.24.0)(eslint@8.57.1):
     resolution: {integrity: sha512-09oMVl/jN0/Re0bT0sEqYjyyFSCN/Tg0YmzjC9wfYpnMx02Apk40XXitySDfUBMR9EgTdr6T4lYknACqiLK3mg==}
     engines: {node: '>=18.0.0'}
     hasBin: true
@@ -33513,7 +33517,7 @@ packages:
       glob: 10.3.4
       log-symbols: 4.1.0
       mime-types: 2.1.35
-      next: 14.1.0(@babel/core@7.26.0)(react-dom@18.3.1)(react@18.3.1)
+      next: 14.1.0(@babel/core@7.24.0)(react-dom@18.3.1)(react@18.3.1)
       normalize-path: 3.0.0
       ora: 5.4.1
       postcss: 8.4.35
@@ -35981,7 +35985,7 @@ packages:
       - '@babel/core'
     dev: false
 
-  /styled-jsx@5.1.1(@babel/core@7.26.0)(react@18.3.1):
+  /styled-jsx@5.1.1(@babel/core@7.24.0)(react@18.3.1):
     resolution: {integrity: sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==}
     engines: {node: '>= 12.0.0'}
     peerDependencies:
@@ -35994,7 +35998,7 @@ packages:
       babel-plugin-macros:
         optional: true
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.24.0
       client-only: 0.0.1
       react: 18.3.1
     dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -512,6 +512,9 @@ importers:
       react-wrap-balancer:
         specifier: ^0.2.4
         version: 0.2.4(react@19.0.0-rc-02c0e824-20241028)
+      reading-time:
+        specifier: ^1.5.0
+        version: 1.5.0
       rehype-raw:
         specifier: ^7.0.0
         version: 7.0.0
@@ -2314,6 +2317,9 @@ importers:
       drizzle-orm:
         specifier: 0.36.0
         version: 0.36.0(@planetscale/database@1.19.0)(@types/pg@8.11.8)(mysql2@3.9.2)(pg@8.12.0)(react@19.0.0-rc-02c0e824-20241028)(types-react@19.0.0-rc.1)
+      egghead:
+        specifier: 'link:'
+        version: 'link:'
       framer-motion:
         specifier: ^12.0.0-alpha.1
         version: 12.0.0-alpha.1(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028)


### PR DESCRIPTION
## Changes

```mermaid
flowchart TD
    subgraph Auth Flow
        Device[Device/Client] -->|Request Code| OAuthCode[oauth/device/code]
        OAuthCode -->|User Code| Device
        User[User Browser] -->|Activate| Verify[activate]
        Verify -->|Verify| Token[oauth/token]
        Token -->|Access Token| Device
    end

    subgraph Content Management
        Device -->|Auth Token| Posts[api/posts]
        Posts -->|CRUD| DB[(Database)]
        Posts -->|Check| CASL{Abilities}
        Device -->|Upload| S3URL[uploads/signed-url]
        S3URL -->|Direct Upload| S3[(S3 Storage)]
        Posts -->|Associate| S3
    end

    subgraph Video Processing
        S3 -->|Trigger| Lambda[Lambda]
        Lambda -->|Process| AI[AI Pipeline]
        AI -->|Update| Posts
    end
```

### Core
- OAuth device flow with activation routes and components
- Posts API with CASL-based access control
- Video resource management and S3 uploads

### Docs
- API documentation for OAuth, Posts, and Video endpoints
- Working OAuth device flow example

### Fixes
- Package dependencies
- Type issues in video upload components
- Default visibility set to public