### PR TITLE
feat: add post metadata to mux player

### DIFF
--- a/apps/ai-hero/src/app/(content)/_components/authed-video-player.tsx
+++ b/apps/ai-hero/src/app/(content)/_components/authed-video-player.tsx
@@ -182,6 +182,10 @@ export function AuthedVideoPlayer({
 	}, [playerRef, handleFullscreenChange])
 	return playbackId ? (
 		<MuxPlayer
+			metadata={{
+				video_id: currentResource.id,
+				video_title: currentResource.fields?.title,
+			}}
 			ref={playerRef}
 			playbackId={playbackId}
 			className={cn(className)}

--- a/apps/ai-hero/src/app/(content)/_components/lesson-player.tsx
+++ b/apps/ai-hero/src/app/(content)/_components/lesson-player.tsx
@@ -32,6 +32,10 @@ export function LessonPlayer({
 		<>
 			{playbackId ? (
 				<MuxPlayer
+					metadata={{
+						video_id: videoResource?.id,
+						video_title: videoResource?.title,
+					}}
 					playbackId={playbackId}
 					className={cn(className)}
 					{...playerProps}

--- a/apps/ai-hero/src/app/(content)/posts/_components/post-player.tsx
+++ b/apps/ai-hero/src/app/(content)/posts/_components/post-player.tsx
@@ -104,6 +104,10 @@ export function PostPlayer({
 		<div className={cn('relative h-full w-full', className)}>
 			{playbackId ? (
 				<MuxPlayer
+					metadata={{
+						video_id: videoResource?.id,
+						video_title: videoResource?.title,
+					}}
 					playbackId={playbackId}
 					className={cn(className)}
 					{...playerProps}
@@ -168,6 +172,10 @@ export function SimplePostPlayer({
 		<>
 			{playbackId ? (
 				<MuxPlayer
+					metadata={{
+						video_id: videoResource?.id,
+						video_title: videoResource?.title,
+					}}
 					playbackId={playbackId}
 					className={cn(className)}
 					{...playerProps}

--- a/apps/ai-hero/src/markdown/mdx-components.tsx
+++ b/apps/ai-hero/src/markdown/mdx-components.tsx
@@ -107,11 +107,15 @@ const YouTube: React.FC<YouTubeProps> = ({ videoId }) => {
 
 type MuxVideoProps = {
 	playbackId: string
+	metadata?: {
+		video_id?: string
+		video_title?: string
+	}
 }
 
-const MuxVideo: React.FC<MuxVideoProps> = ({ playbackId }) => {
+const MuxVideo: React.FC<MuxVideoProps> = ({ playbackId, metadata }) => {
 	return playbackId ? (
-		<MuxPlayer data-body-video="" playbackId={playbackId} />
+		<MuxPlayer data-body-video="" playbackId={playbackId} metadata={metadata} />
 	) : null
 }
 

--- a/apps/astro-party/src/app/(content)/_components/authed-video-player.tsx
+++ b/apps/astro-party/src/app/(content)/_components/authed-video-player.tsx
@@ -172,6 +172,10 @@ export function AuthedVideoPlayer({
 	}, [playerRef, handleFullscreenChange])
 	return playbackId ? (
 		<MuxPlayer
+			metadata={{
+				video_id: currentResource.id,
+				video_title: currentResource.fields?.title,
+			}}
 			ref={playerRef}
 			playbackId={playbackId}
 			className={cn(className)}

--- a/apps/astro-party/src/app/(content)/_components/post-player.tsx
+++ b/apps/astro-party/src/app/(content)/_components/post-player.tsx
@@ -35,6 +35,10 @@ export function PostPlayer({
 		<>
 			{playbackId ? (
 				<MuxPlayer
+					metadata={{
+						video_id: videoResource?.id,
+						video_title: videoResource?.title,
+					}}
 					playbackId={playbackId}
 					className={cn(className)}
 					{...playerProps}

--- a/apps/astro-party/src/app/(content)/workshops/[module]/[lesson]/edit/_components/lesson-player.tsx
+++ b/apps/astro-party/src/app/(content)/workshops/[module]/[lesson]/edit/_components/lesson-player.tsx
@@ -32,6 +32,10 @@ export function LessonPlayer({
 		<>
 			{playbackId ? (
 				<MuxPlayer
+					metadata={{
+						video_id: videoResource?.id,
+						video_title: videoResource?.title,
+					}}
 					playbackId={playbackId}
 					className={cn(className)}
 					{...playerProps}

--- a/apps/astro-party/src/components/resources-crud/lesson-player.tsx
+++ b/apps/astro-party/src/components/resources-crud/lesson-player.tsx
@@ -32,6 +32,10 @@ export function LessonPlayer({
 		<>
 			{playbackId ? (
 				<MuxPlayer
+					metadata={{
+						video_id: videoResource?.id,
+						video_title: videoResource?.title,
+					}}
 					playbackId={playbackId}
 					className={cn(className)}
 					{...playerProps}

--- a/apps/course-builder-web/src/app/(content)/tutorials/[module]/[lesson]/edit/_components/lesson-player.tsx
+++ b/apps/course-builder-web/src/app/(content)/tutorials/[module]/[lesson]/edit/_components/lesson-player.tsx
@@ -32,6 +32,10 @@ export function LessonPlayer({
 		<>
 			{playbackId ? (
 				<MuxPlayer
+					metadata={{
+						video_id: videoResource?.id,
+						video_title: videoResource?.title,
+					}}
 					playbackId={playbackId}
 					className={cn(className)}
 					{...playerProps}

--- a/apps/egghead/src/app/(content)/posts/_components/post-player.tsx
+++ b/apps/egghead/src/app/(content)/posts/_components/post-player.tsx
@@ -37,6 +37,10 @@ export function PostPlayer({
 		<>
 			{playbackId ? (
 				<MuxPlayer
+					metadata={{
+						video_id: videoResource?.id,
+						video_title: videoResource?.title,
+					}}
 					playbackId={playbackId}
 					className={cn(className)}
 					{...playerProps}

--- a/apps/epic-react/src/app/(content)/posts/_components/post-player.tsx
+++ b/apps/epic-react/src/app/(content)/posts/_components/post-player.tsx
@@ -37,6 +37,10 @@ export function PostPlayer({
 		<>
 			{playbackId ? (
 				<MuxPlayer
+					metadata={{
+						video_id: videoResource?.id,
+						video_title: videoResource?.title,
+					}}
 					playbackId={playbackId}
 					className={cn(className)}
 					{...playerProps}

--- a/apps/go-local-first/src/app/(content)/posts/_components/post-player.tsx
+++ b/apps/go-local-first/src/app/(content)/posts/_components/post-player.tsx
@@ -38,6 +38,10 @@ export function PostPlayer({
 		<>
 			{playbackId ? (
 				<MuxPlayer
+					metadata={{
+						video_id: videoResource?.id,
+						video_title: videoResource?.title,
+					}}
 					playbackId={playbackId}
 					className={cn(className)}
 					{...playerProps}

--- a/packages/commerce-next/src/post-purchase/welcome-page.tsx
+++ b/packages/commerce-next/src/post-purchase/welcome-page.tsx
@@ -90,6 +90,9 @@ export function WelcomePage({
 								Introduction
 							</h2>
 							<MuxPlayer
+								metadata={{
+									video_title: `${product?.name} Welcome Video`,
+								}}
 								poster={welcomeVideoPosterImageUrl}
 								className="overflow-hidden rounded-md shadow-2xl shadow-black/30"
 								playbackId={welcomeVideoPlaybackId}


### PR DESCRIPTION
this adds post metadata for all the mux player instances in course builder products.

![gif](https://media0.giphy.com/media/glvNGHmbZwgrKH4YYA/giphy.gif?cid=1927fc1bl5ngnxx7v4unozwn1eq6e5vfbcsexnccqtql0t8k&ep=v1_gifs_search&rid=giphy.gif&ct=g)