### PR TITLE
fix(egh): create rails playlist with egh user id not instructor id

### DIFF
--- a/apps/egghead/src/app/api/posts/route.ts
+++ b/apps/egghead/src/app/api/posts/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { courseBuilderAdapter } from '@/db'
-import { getEggheadUserId, getEggheadUserProfile } from '@/lib/egghead'
+import { getEggheadUserProfile } from '@/lib/egghead'
 import { NewPostSchema, PostActionSchema, PostUpdateSchema } from '@/lib/posts'
 import { writeNewPostToDatabase } from '@/lib/posts-new-query'
 import {
@@ -83,9 +83,8 @@ export async function POST(request: NextRequest) {
 	}
 
 	const profile = await getEggheadUserProfile(user.id)
-	const eggheadUserId = await getEggheadUserId(user.id)
 
-	if (!profile.instructor.id) {
+	if (!profile?.instructor?.id) {
 		return NextResponse.json(
 			{ error: 'Unauthorized: egghead instructor profile not found' },
 			{ status: 401, headers: corsHeaders },
@@ -98,7 +97,7 @@ export async function POST(request: NextRequest) {
 			videoResourceId: validatedData.data.videoResourceId || undefined,
 			postType: validatedData.data.postType,
 			eggheadInstructorId: profile.instructor.id,
-			eggheadUserId,
+			eggheadUserId: profile.id,
 			createdById: user.id,
 		})
 		return NextResponse.json(newPost, { status: 201, headers: corsHeaders })

--- a/apps/egghead/src/app/api/posts/route.ts
+++ b/apps/egghead/src/app/api/posts/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { courseBuilderAdapter } from '@/db'
-import { getEggheadUserProfile } from '@/lib/egghead'
+import { getEggheadUserId, getEggheadUserProfile } from '@/lib/egghead'
 import { NewPostSchema, PostActionSchema, PostUpdateSchema } from '@/lib/posts'
 import { writeNewPostToDatabase } from '@/lib/posts-new-query'
 import {
@@ -83,6 +83,7 @@ export async function POST(request: NextRequest) {
 	}
 
 	const profile = await getEggheadUserProfile(user.id)
+	const eggheadUserId = await getEggheadUserId(user.id)
 
 	if (!profile.instructor.id) {
 		return NextResponse.json(
@@ -97,6 +98,7 @@ export async function POST(request: NextRequest) {
 			videoResourceId: validatedData.data.videoResourceId || undefined,
 			postType: validatedData.data.postType,
 			eggheadInstructorId: profile.instructor.id,
+			eggheadUserId,
 			createdById: user.id,
 		})
 		return NextResponse.json(newPost, { status: 201, headers: corsHeaders })

--- a/apps/egghead/src/inngest/functions/notify-slack-for-post.ts
+++ b/apps/egghead/src/inngest/functions/notify-slack-for-post.ts
@@ -32,8 +32,8 @@ export const notifySlack = inngest.createFunction(
 				text: `New ${post?.fields?.postType} created: ${post?.fields?.title}`,
 				attachments: [
 					{
-						author_name: instructor.name ?? '',
-						author_icon: instructor.image ?? '',
+						author_name: instructor?.full_name ?? '',
+						author_icon: instructor?.avatar_url ?? '',
 						mrkdwn_in: ['text'],
 						title: post?.fields?.title ?? '',
 						title_link: `${process.env.NEXT_PUBLIC_URL}/${post?.fields?.slug}`,

--- a/apps/egghead/src/lib/egghead.ts
+++ b/apps/egghead/src/lib/egghead.ts
@@ -65,6 +65,25 @@ export async function getEggheadUserProfile(userId: string) {
 	return profile
 }
 
+export async function getEggheadUserId(userId: string) {
+	const user = await db.query.users.findFirst({
+		where: eq(users.id, userId),
+		with: {
+			accounts: true,
+		},
+	})
+	const eggheadAccount = user?.accounts.find(
+		(account) => account.provider === 'egghead',
+	)
+	const eggheadUserId = Number(eggheadAccount?.providerAccountId)
+
+	if (!eggheadUserId) {
+		throw new Error(`No egghead user id found for user ${userId}`)
+	}
+
+	return eggheadUserId
+}
+
 const EGGHEAD_LESSON_TYPE = 'lesson'
 const EGGHEAD_INITIAL_LESSON_STATE = 'approved'
 

--- a/apps/egghead/src/lib/egghead.ts
+++ b/apps/egghead/src/lib/egghead.ts
@@ -62,26 +62,15 @@ export async function getEggheadUserProfile(userId: string) {
 		return await res.json()
 	})
 
-	return profile
-}
+	const parsedProfile = EggheadCurrentUserSchema.safeParse(profile)
 
-export async function getEggheadUserId(userId: string) {
-	const user = await db.query.users.findFirst({
-		where: eq(users.id, userId),
-		with: {
-			accounts: true,
-		},
-	})
-	const eggheadAccount = user?.accounts.find(
-		(account) => account.provider === 'egghead',
-	)
-	const eggheadUserId = Number(eggheadAccount?.providerAccountId)
-
-	if (!eggheadUserId) {
-		throw new Error(`No egghead user id found for user ${userId}`)
+	if (!parsedProfile.success) {
+		throw new Error('Failed to parse egghead profile', {
+			cause: parsedProfile.error.flatten().fieldErrors,
+		})
 	}
 
-	return eggheadUserId
+	return parsedProfile.data
 }
 
 const EGGHEAD_LESSON_TYPE = 'lesson'
@@ -407,3 +396,125 @@ export async function createEggheadCourse(input: {
 
 	return eggheadCourse.data
 }
+
+export const EggheadCurrentUserInstructorSchema = z.object({
+	id: z.number(),
+	slug: z.string().optional(),
+	full_name: z.string().optional(),
+	first_name: z.string().optional(),
+	last_name: z.string().optional(),
+	twitter: z.string().optional(),
+	website: z.string().optional(),
+	bio_short: z.string().optional(),
+	state: z.string().optional(),
+	http_url: z.string().optional(),
+	path: z.string().optional(),
+	avatar_url: z.string().optional(),
+	avatar_480_url: z.string().optional(),
+	avatar_280_url: z.string().optional(),
+	avatar_256_url: z.string().optional(),
+	avatar_128_url: z.string().optional(),
+	avatar_64_url: z.string().optional(),
+	avatar_32_url: z.string().optional(),
+	lessons_url: z.string().optional(),
+	lesson_tags: z.array(z.any()).optional(),
+	published_lessons: z.number().optional(),
+	published_courses: z.number().optional(),
+	edit_instructor_http_url: z.string().optional(),
+	api_v1_update_instructor_url: z.string().optional(),
+	rss_url: z.string().optional(),
+	slack_id: z.string().optional(),
+	slack_group_id: z.string().optional(),
+	email: z.string().optional(),
+	gear_tracking_number: z.null().optional(),
+	pending_courses: z.number().optional(),
+	pending_lessons: z.number().optional(),
+	claimed_lessons: z.number().optional(),
+	submitted_lessons: z.number().optional(),
+	approved_lessons: z.number().optional(),
+	reviewing_lessons: z.number().optional(),
+	updated_lessons: z.number().optional(),
+	revenue_url: z.string().optional(),
+	affiliate_http_url: z.string().optional(),
+	stats_url: z.string().optional(),
+	playlists_url: z.string().optional(),
+})
+export type EggheadCurrentUserInstructor = z.infer<
+	typeof EggheadCurrentUserInstructorSchema
+>
+
+export const EggheadCurrentUserSchema = z.object({
+	name: z.string().optional(),
+	id: z.number(),
+	lessons_completed: z.number().optional(),
+	series_completed: z.number().optional(),
+	email: z.string().optional(),
+	is_unverified_email: z.boolean().optional(),
+	full_name: z.string().optional(),
+	discord_id: z.string().optional(),
+	avatar_url: z.string().optional(),
+	contact_id: z.string().optional(),
+	roles: z.array(z.string()).optional(),
+	accounts: z.array(z.any()).optional(),
+	can_comment: z.boolean().optional(),
+	providers: z.array(z.string()).optional(),
+	created_at: z.number().optional(),
+	opted_out: z.boolean().optional(),
+	stripeKey: z.string().optional(),
+	is_pro: z.boolean().optional(),
+	is_instructor: z.boolean().optional(),
+	instructor_id: z.number().optional(),
+	is_cancelled: z.boolean().optional(),
+	is_community_member: z.boolean().optional(),
+	user_profile_url: z.string().optional(),
+	username: z.string().optional(),
+	user_url: z.string().optional(),
+	watch_later_bookmarks_url: z.string().optional(),
+	lessons_url: z.string().optional(),
+	series_url: z.string().optional(),
+	answer_quiz_url: z.string().optional(),
+	recommended_lessons_url: z.string().optional(),
+	recommended_series_url: z.string().optional(),
+	in_progress_series_url: z.string().optional(),
+	timezone: z.string().optional(),
+	last_lesson_completed_at: z.coerce.date().optional(),
+	current_course_url: z.string().optional(),
+	current_course: z.any(),
+	tags: z.array(z.any()).optional(),
+	subscription: z.any(),
+	purchased: z.array(z.any()).optional(),
+	deals: z.array(z.any()).optional(),
+	instructor_url: z.string().optional(),
+	instructor: EggheadCurrentUserInstructorSchema.optional(),
+	new_lesson_http_url: z.string().optional(),
+	new_lesson_url: z.string().optional(),
+	production_board_path: z.string().optional(),
+	production_board_url: z.string().optional(),
+	playlists_url: z.string().optional(),
+	watch_later_url: z.string().optional(),
+	collections_http_url: z.string().optional(),
+	edit_user_url: z.string().optional(),
+	edit_user_password_url: z.string().optional(),
+	membership_url: z.string().optional(),
+	favorites: z.array(z.string()).optional(),
+	favorite_topic: z.string().optional(),
+	managed_subscription_url: z.string().optional(),
+	search_api_v1_users: z.string().optional(),
+	api_v1_users: z.string().optional(),
+	become_user_url: z.string().optional(),
+	events_url: z.string().optional(),
+	view_egghead_apex_as_user_url: z.string().optional(),
+	last_sign_in_at: z.coerce.date().optional(),
+	is_banned: z.boolean().optional(),
+	has_random_password: z.null().optional(),
+	new_playlist_url: z.string().optional(),
+	new_playlist_http_url: z.string().optional(),
+	new_resource_files_url: z.string().optional(),
+	new_resource_urls_url: z.string().optional(),
+	reorder_course_publication_queue_url: z.string().optional(),
+	new_tag_url: z.string().optional(),
+	s3_signing_url: z.string().optional(),
+	api_v1_podcast_shows_url: z.string().optional(),
+	api_v1_responses_url: z.string().optional(),
+})
+export type EggheadCurrentUser = z.infer<typeof EggheadCurrentUserSchema>

--- a/apps/egghead/src/lib/instructor-query.ts
+++ b/apps/egghead/src/lib/instructor-query.ts
@@ -1,9 +1,9 @@
-import { InstructorProfile } from '@/lib/instructor'
+import { EggheadCurrentUser } from '@/lib/egghead'
 import { sanityWriteClient } from '@/server/sanity-write-client'
 import { guid } from '@/utils/guid'
 
-export const syncInstructorToSanity = async (profile: InstructorProfile) => {
-	if (!profile.instructor) return
+export const syncInstructorToSanity = async (profile: EggheadCurrentUser) => {
+	if (!profile?.instructor) return
 	const existingPerson = await sanityWriteClient.fetch(
 		`*[_type == "person" && slug.current == "${profile.instructor.slug}"][0]`,
 	)
@@ -40,11 +40,13 @@ export const syncInstructorToSanity = async (profile: InstructorProfile) => {
 			await sanityWriteClient.create({
 				_id: personId,
 				_type: 'person',
-				name: `${profile.instructor.first_name || profile.first_name} ${profile.instructor.last_name || profile.last_name}`,
+				name: `${profile.instructor.first_name || profile?.name} ${profile.instructor.last_name}`,
 				slug: { current: profile.instructor.slug },
 				image: {
 					label: 'avatar',
-					url: profile.instructor.avatar_480_url || profile.avatar_480_url,
+					url:
+						profile.instructor.avatar_480_url ||
+						profile.instructor?.avatar_480_url,
 				},
 			})
 

--- a/apps/egghead/src/lib/posts-new-query.ts
+++ b/apps/egghead/src/lib/posts-new-query.ts
@@ -44,6 +44,7 @@ const NewPostInputSchema = z.object({
 		'article',
 	]),
 	eggheadInstructorId: z.number(),
+	eggheadUserId: z.number(),
 	createdById: z.string(),
 })
 
@@ -62,6 +63,7 @@ export async function writeNewPostToDatabase(
 			videoResourceId,
 			postType,
 			eggheadInstructorId,
+			eggheadUserId,
 			createdById,
 		} = validatedInput
 
@@ -91,6 +93,7 @@ export async function writeNewPostToDatabase(
 				postGuid,
 				postType,
 				eggheadInstructorId,
+				eggheadUserId,
 				videoResource,
 			})
 
@@ -160,12 +163,14 @@ async function createExternalResources({
 	postGuid,
 	postType,
 	eggheadInstructorId,
+	eggheadUserId,
 	videoResource,
 }: {
 	title: string
 	postGuid: string
 	postType: string
 	eggheadInstructorId: number
+	eggheadUserId: number
 	videoResource: any
 }) {
 	const isLessonType = TYPES_WITH_LESSONS.includes(postType as any)
@@ -216,7 +221,7 @@ async function createExternalResources({
 			const playlist = await createEggheadCourse({
 				title,
 				guid: postGuid,
-				ownerId: eggheadInstructorId,
+				ownerId: eggheadUserId,
 			})
 
 			if (!playlist) {

--- a/apps/egghead/src/lib/posts-query.ts
+++ b/apps/egghead/src/lib/posts-query.ts
@@ -44,7 +44,6 @@ import {
 	determineEggheadAccess,
 	determineEggheadLessonState,
 	determineEggheadVisibilityState,
-	getEggheadUserId,
 	getEggheadUserProfile,
 	setPublishedAt,
 	updateEggheadLesson,
@@ -249,14 +248,17 @@ export async function createPost(input: NewPost) {
 	}
 
 	const profile = await getEggheadUserProfile(session.user.id)
-	const eggheadUserId = await getEggheadUserId(session.user.id)
+
+	if (!profile?.instructor?.id) {
+		throw new Error('No egghead instructor id found for user')
+	}
 
 	const post = await writeNewPostToDatabase({
 		title: input.title,
 		videoResourceId: input.videoResourceId || undefined,
 		postType: input.postType,
 		eggheadInstructorId: profile.instructor.id,
-		eggheadUserId,
+		eggheadUserId: profile.id,
 		createdById: session.user.id,
 	})
 

--- a/apps/egghead/src/lib/posts-query.ts
+++ b/apps/egghead/src/lib/posts-query.ts
@@ -44,6 +44,7 @@ import {
 	determineEggheadAccess,
 	determineEggheadLessonState,
 	determineEggheadVisibilityState,
+	getEggheadUserId,
 	getEggheadUserProfile,
 	setPublishedAt,
 	updateEggheadLesson,
@@ -248,20 +249,7 @@ export async function createPost(input: NewPost) {
 	}
 
 	const profile = await getEggheadUserProfile(session.user.id)
-	const user = await db.query.users.findFirst({
-		where: eq(users.id, session.user.id),
-		with: {
-			accounts: true,
-		},
-	})
-	const eggheadAccount = user?.accounts.find(
-		(account) => account.provider === 'egghead',
-	)
-	const eggheadUserId = Number(eggheadAccount?.providerAccountId)
-
-	if (!eggheadUserId) {
-		throw new Error(`No egghead user id found for user ${session.user.id}`)
-	}
+	const eggheadUserId = await getEggheadUserId(session.user.id)
 
 	const post = await writeNewPostToDatabase({
 		title: input.title,


### PR DESCRIPTION
Looking at the rails object after creating a course in builder I noticed 'user created' label. We were passing the instructor id as the `owner_id` which rails expects the users id so creating courses was assigning the course to wrong users.


The initial confusion might stem from the fact that `getEggheadUserProfile` gets the current users _instructor_ profile

![image](https://github.com/user-attachments/assets/ae133296-7368-4b5a-a65a-63b3c97f9d1e)



![image](https://github.com/user-attachments/assets/a3816e6e-95ee-4d07-99a5-17e88a07aecc)



![gif](https://media3.giphy.com/media/fnuSiwXMTV3zmYDf6k/giphy.gif?cid=1927fc1ba9tys32utm7iz3ymjql4qykm6kn8oi0zbi3v1szc&ep=v1_gifs_search&rid=giphy.gif&ct=g)