### PR TITLE
feat(egh): add course info to TypeSense

### DIFF
--- a/apps/egghead/src/lib/egghead.ts
+++ b/apps/egghead/src/lib/egghead.ts
@@ -241,6 +241,50 @@ export async function updateEggheadLesson(input: {
 	)
 }
 
+export async function updateEggheadPlaylist(input: {
+	eggheadPlaylistId: number
+	title: string
+	slug: string
+	guid: string
+	state: string
+	visibilityState: string
+	accessState: string
+	body?: string
+}) {
+	const {
+		eggheadPlaylistId,
+		state,
+		visibilityState,
+		accessState,
+		title,
+		slug,
+		guid,
+		body = '',
+	} = input
+	await eggheadPgQuery(
+		`UPDATE playlists SET
+			state = $1,
+			updated_at = NOW(),
+			visibility_state = $2,
+			title = $3,
+			slug = $4,
+			guid = $5,
+			summary = $6,
+			access_state = $8
+		WHERE id = $7`,
+		[
+			state,
+			visibilityState,
+			title,
+			slug,
+			guid,
+			body,
+			eggheadPlaylistId,
+			accessState,
+		],
+	)
+}
+
 export function setLessonPublishedAt(
 	eggheadLessonId: number,
 	publishedAt: string,
@@ -251,7 +295,7 @@ export function setLessonPublishedAt(
 	])
 }
 
-export function clearPublishedAt(eggheadLessonId: number) {
+export function clearLessonPublishedAt(eggheadLessonId: number) {
 	return eggheadPgQuery(
 		`UPDATE lessons SET published_at = NULL WHERE id = $1`,
 		[eggheadLessonId],
@@ -571,6 +615,13 @@ export function setPlaylistPublishedAt(
 	return eggheadPgQuery(
 		`UPDATE playlists SET published_at = $1 WHERE id = $2`,
 		[publishedAt, eggheadPlaylistId],
+	)
+}
+
+export function clearPlaylistPublishedAt(eggheadPlaylistId: number) {
+	return eggheadPgQuery(
+		`UPDATE playlists SET published_at = NULL WHERE id = $1`,
+		[eggheadPlaylistId],
 	)
 }
 

--- a/apps/egghead/src/lib/posts-query.ts
+++ b/apps/egghead/src/lib/posts-query.ts
@@ -688,6 +688,27 @@ export async function addEggheadLessonToPlaylist({
 	}
 }
 
+export async function getCoursesForPost(postId: string) {
+	return await db
+		.select({
+			courseId: contentResource.id,
+			courseTitle: sql`JSON_EXTRACT(${contentResource.fields}, '$.title')`,
+			courseSlug: sql`JSON_EXTRACT(${contentResource.fields}, '$.slug')`,
+			eggheadPlaylistId: sql`JSON_EXTRACT(${contentResource.fields}, '$.eggheadPlaylistId')`,
+		})
+		.from(contentResource)
+		.innerJoin(
+			contentResourceResource,
+			eq(contentResource.id, contentResourceResource.resourceOfId),
+		)
+		.where(
+			and(
+				eq(contentResourceResource.resourceId, postId),
+				sql`JSON_EXTRACT(${contentResource.fields}, '$.postType') = 'course'`,
+			),
+		)
+}
+
 export async function removePostFromCoursePost({
 	postId,
 	resourceOfId,

--- a/apps/egghead/src/lib/typesense-query.ts
+++ b/apps/egghead/src/lib/typesense-query.ts
@@ -79,7 +79,8 @@ export async function upsertPostToTypeSense(post: Post, action: PostAction) {
 					? new Date(eggheadResource.published_at).getTime()
 					: null,
 			}),
-			belongs_to_course: courses.length > 0,
+			belongs_to_course:
+				courses.length > 0 ? courses[0]?.eggheadPlaylistId : null,
 			...(courses.length > 0 && {
 				courses: courses.map((course) => ({
 					id: course.courseId,

--- a/apps/egghead/src/lib/typesense-query.ts
+++ b/apps/egghead/src/lib/typesense-query.ts
@@ -79,10 +79,10 @@ export async function upsertPostToTypeSense(post: Post, action: PostAction) {
 					? new Date(eggheadResource.published_at).getTime()
 					: null,
 			}),
-			belongs_to_course:
+			belongs_to_resource:
 				courses.length > 0 ? courses[0]?.eggheadPlaylistId : null,
 			...(courses.length > 0 && {
-				courses: courses.map((course) => ({
+				resources: courses.map((course) => ({
 					id: course.courseId,
 					title: course.courseTitle,
 					slug: course.courseSlug,

--- a/apps/egghead/src/lib/typesense.ts
+++ b/apps/egghead/src/lib/typesense.ts
@@ -29,8 +29,8 @@ export const TypesensePostSchema = z.object({
 	instructor_url: z.string().url().optional(),
 	path: z.string().optional(),
 	published_at_timestamp: z.number().nullish(),
-	belongs_to_course: z.number().nullish(),
-	courses: z
+	belongs_to_resource: z.number().nullish(),
+	resources: z
 		.array(
 			z.object({
 				id: z.string(),

--- a/apps/egghead/src/lib/typesense.ts
+++ b/apps/egghead/src/lib/typesense.ts
@@ -29,7 +29,7 @@ export const TypesensePostSchema = z.object({
 	instructor_url: z.string().url().optional(),
 	path: z.string().optional(),
 	published_at_timestamp: z.number().nullish(),
-	belongs_to_course: z.boolean().optional(),
+	belongs_to_course: z.number().nullish(),
 	courses: z
 		.array(
 			z.object({

--- a/apps/egghead/src/lib/typesense.ts
+++ b/apps/egghead/src/lib/typesense.ts
@@ -29,6 +29,17 @@ export const TypesensePostSchema = z.object({
 	instructor_url: z.string().url().optional(),
 	path: z.string().optional(),
 	published_at_timestamp: z.number().nullish(),
+	belongs_to_course: z.boolean().optional(),
+	courses: z
+		.array(
+			z.object({
+				id: z.string(),
+				title: z.string(),
+				slug: z.string(),
+				eggheadPlaylistId: z.number(),
+			}),
+		)
+		.optional(),
 })
 
 const TypesenseResourceSchema = z.object({


### PR DESCRIPTION
The Feed on egghead-next gets clogged up with course lessons if an instructor publishes them all at once. This adds `resources` array and `belongs_to_resource` boolean to typesense data so that we can sort (effectively filter out) lessons in courses in a new preset called `the_feed`. 

TypeSense does not let you filter on null values but the workaround is to sort missing values to the bottom (`belongs_to_resource(missing_values: first):desc`). We set `belongs_to_resource` to the id of the resource the current resource belongs to.

We also weren't updating the egghead playlist on publish to properly index it so this adds that as well

related
https://github.com/skillrecordings/egghead-next/pull/1508

![gif](https://media1.giphy.com/media/kQmr2OwBTD2L5Hzo1T/giphy.gif?cid=1927fc1brcx1xgc5j3rgjhgtm0244p7gluigotszsh6hog9y&ep=v1_gifs_search&rid=giphy.gif&ct=g)