### PR TITLE
feat(egh): add image field support for posts

### DIFF
--- a/apps/egghead/src/app/(content)/posts/_components/edit-post-form-metadata.tsx
+++ b/apps/egghead/src/app/(content)/posts/_components/edit-post-form-metadata.tsx
@@ -203,6 +203,36 @@ export const PostMetadataFormFields: React.FC<{
 				name="id"
 				render={({ field }) => <Input type="hidden" {...field} />}
 			/>
+			<div className="px-5">
+				<FormLabel>Cover Image</FormLabel>
+				{form.watch('fields.image') && <img src={form.watch('fields.image')} />}
+			</div>
+			<FormField
+				control={form.control}
+				name="fields.image"
+				render={({ field }) => (
+					<FormItem className="px-5">
+						<FormLabel>Image URL</FormLabel>
+						<Input
+							{...field}
+							onDrop={(e) => {
+								e.preventDefault()
+								const result = e.dataTransfer.getData('text/plain')
+								// Check if it's a markdown image format
+								const markdownMatch = result.match(/\(([^)]+)\)/)
+								if (markdownMatch) {
+									field.onChange(markdownMatch[1])
+								} else {
+									// If not markdown, use the plain text URL
+									field.onChange(result)
+								}
+							}}
+							value={field.value || ''}
+						/>
+						<FormMessage />
+					</FormItem>
+				)}
+			/>
 			<FormField
 				control={form.control}
 				name="fields.postType"

--- a/apps/egghead/src/app/(content)/posts/_components/edit-post-form.tsx
+++ b/apps/egghead/src/app/(content)/posts/_components/edit-post-form.tsx
@@ -7,6 +7,7 @@ import {
 	onPostPublish,
 	onPostSave,
 } from '@/app/(content)/posts/[slug]/edit/actions'
+import { ImageResourceUploader } from '@/components/image-uploader/image-resource-uploader'
 import { env } from '@/env.mjs'
 import { useIsMobile } from '@/hooks/use-is-mobile'
 import { sendResourceChatMessage } from '@/lib/ai-chat-query'
@@ -15,7 +16,12 @@ import { updatePost } from '@/lib/posts-query'
 import { EggheadTag } from '@/lib/tags'
 import { CompactInstructor } from '@/lib/users'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { CheckIcon, ListOrderedIcon } from 'lucide-react'
+import {
+	CheckIcon,
+	ImageIcon,
+	ImagePlusIcon,
+	ListOrderedIcon,
+} from 'lucide-react'
 import { useSession } from 'next-auth/react'
 import { useTheme } from 'next-themes'
 import { useForm, type UseFormReturn } from 'react-hook-form'
@@ -134,6 +140,19 @@ export function EditPostForm({
 					toolComponent: <PublishPostChecklist key={'post-checklist'} />,
 				},
 				{ id: 'assistant' },
+				{
+					id: 'media',
+					icon: () => (
+						<ImagePlusIcon strokeWidth={1.5} size={24} width={18} height={18} />
+					),
+					toolComponent: (
+						<ImageResourceUploader
+							key={'image-uploader'}
+							belongsToResourceId={post.id}
+							uploadDirectory={`posts`}
+						/>
+					),
+				},
 			]}
 		>
 			<PostMetadataFormFields

--- a/apps/egghead/src/app/(content)/posts/_components/edit-post-form.tsx
+++ b/apps/egghead/src/app/(content)/posts/_components/edit-post-form.tsx
@@ -72,6 +72,7 @@ export function EditPostForm({
 		defaultValues: {
 			id: post.id,
 			fields: {
+				image: post.fields?.image ?? '',
 				title: post.fields?.title,
 				postType: post.fields?.postType || 'lesson',
 				body: post.fields?.body,

--- a/apps/egghead/src/lib/posts-new-query.ts
+++ b/apps/egghead/src/lib/posts-new-query.ts
@@ -378,6 +378,7 @@ async function updateExternalSystems({
 				productionProcessState: 'new',
 				sharedId: postGuid,
 				railsCourseId: eggheadPlaylistId,
+				image: fields?.image,
 			})
 
 			if (!coursePayload.success) {

--- a/apps/egghead/src/lib/posts-query.ts
+++ b/apps/egghead/src/lib/posts-query.ts
@@ -551,6 +551,7 @@ export async function writePostUpdateToDatabase(input: {
 			productionProcessState: postUpdate.fields.state,
 			accessLevel: postUpdate.fields.access,
 			searchIndexingState: postUpdate.fields.visibility,
+			image: postUpdate.fields.image || '',
 		})
 
 		if (action === 'publish') {

--- a/apps/egghead/src/lib/posts.ts
+++ b/apps/egghead/src/lib/posts.ts
@@ -51,6 +51,7 @@ export const PostSchema = ContentResourceSchema.merge(
 	z.object({
 		fields: z.object({
 			title: z.string(),
+			image: z.string().nullish(),
 			postType: PostTypeSchema.default('lesson'),
 			summary: z.string().optional().nullable(),
 			body: z.string().nullable().optional(),

--- a/apps/egghead/src/lib/sanity-content-query.ts
+++ b/apps/egghead/src/lib/sanity-content-query.ts
@@ -550,6 +550,7 @@ export async function updateSanityCourseMetadata({
 	productionProcessState,
 	accessLevel,
 	searchIndexingState,
+	image,
 }: {
 	eggheadPlaylistId: number
 	title: string
@@ -559,6 +560,7 @@ export async function updateSanityCourseMetadata({
 	productionProcessState: string
 	accessLevel: string
 	searchIndexingState: string
+	image: string
 }) {
 	const sanityCourse =
 		await getSanityCourseForEggheadCourseId(eggheadPlaylistId)
@@ -581,6 +583,7 @@ export async function updateSanityCourseMetadata({
 			accessLevel,
 			searchIndexingState:
 				searchIndexingState === 'public' ? 'indexed' : 'hidden',
+			image,
 		})
 		.commit()
 }

--- a/apps/egghead/src/lib/typesense-query.ts
+++ b/apps/egghead/src/lib/typesense-query.ts
@@ -59,7 +59,7 @@ export async function upsertPostToTypeSense(post: Post, action: PostAction) {
 			name: post.fields.title,
 			path: `/${post.fields.slug}`,
 			type: postType,
-			image: post.tags?.[0]?.tag?.fields?.image_url,
+			image: post.fields.image || post.tags?.[0]?.tag?.fields?.image_url,
 			_tags: post.tags?.map(({ tag }) => tag.fields?.name),
 			...(primaryTagDbRow && {
 				primary_tag: primaryTagDbRow.tag,


### PR DESCRIPTION
This PR adds support for cover images in posts, including:

- New image field in post metadata form with drag & drop support for URLs
- Image uploader component integration
- Propagation to Sanity and TypeSense

![painting](https://media4.giphy.com/media/d31vTpVi1LAcDvdm/giphy.gif?cid=01d288b0as871927zolmsz3bn9vtu47obl0qna8rxn53prro&ep=v1_gifs_search&rid=giphy.gif&ct=g)