### PR TITLE
fix(aih): redirect upon saving resource with new slug

### DIFF
--- a/apps/ai-hero/src/app/(content)/lists/[slug]/edit/_components/list-form.tsx
+++ b/apps/ai-hero/src/app/(content)/lists/[slug]/edit/_components/list-form.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import * as React from 'react'
+import { useRouter } from 'next/navigation'
 import {
 	withResourceForm,
 	type ResourceFormProps,
@@ -29,10 +30,13 @@ function BaseListForm({
 
 /**
  * Enhanced list form with resource form functionality
+ * @param {Object} props - Component props
+ * @param {List} props.resource - The list resource to edit
  */
-export const ListForm = withResourceForm<List, typeof ListSchema>(
-	BaseListForm,
-	{
+export function EditListForm({ resource }: { resource: List }) {
+	const router = useRouter()
+
+	const ListForm = withResourceForm<List, typeof ListSchema>(BaseListForm, {
 		resourceType: 'list',
 		schema: ListSchema,
 		defaultValues: (resource) => ({
@@ -98,6 +102,11 @@ export const ListForm = withResourceForm<List, typeof ListSchema>(
 				type: 'list',
 			} as List
 		},
+		onSave: async (resource, isSlugMismatch) => {
+			if (isSlugMismatch) {
+				router.push(`/lists/${resource.fields?.slug}/edit`)
+			}
+		},
 		bodyPanelConfig: {
 			showListResources: true,
 			listEditorConfig: {
@@ -117,5 +126,7 @@ export const ListForm = withResourceForm<List, typeof ListSchema>(
 			defaultResourceType: 'article',
 			availableResourceTypes: ['article'],
 		},
-	},
-)
+	})
+
+	return <ListForm resource={resource} />
+}

--- a/apps/ai-hero/src/app/(content)/lists/[slug]/edit/_components/list-form.tsx
+++ b/apps/ai-hero/src/app/(content)/lists/[slug]/edit/_components/list-form.tsx
@@ -102,8 +102,8 @@ export function EditListForm({ resource }: { resource: List }) {
 				type: 'list',
 			} as List
 		},
-		onSave: async (resource, isSlugMismatch) => {
-			if (isSlugMismatch) {
+		onSave: async (resource, hasNewSlug) => {
+			if (hasNewSlug) {
 				router.push(`/lists/${resource.fields?.slug}/edit`)
 			}
 		},

--- a/apps/ai-hero/src/app/(content)/lists/[slug]/edit/page.tsx
+++ b/apps/ai-hero/src/app/(content)/lists/[slug]/edit/page.tsx
@@ -4,7 +4,7 @@ import { getList } from '@/lib/lists-query'
 import { getServerAuthSession } from '@/server/auth'
 import { subject } from '@casl/ability'
 
-import { ListForm } from './_components/list-form'
+import { EditListForm } from './_components/list-form'
 
 export const dynamic = 'force-dynamic'
 
@@ -44,5 +44,5 @@ export default async function ListEditPage(props: {
 		redirect(`/${list?.fields?.slug}`)
 	}
 
-	return <ListForm key={list.fields.slug} resource={list} />
+	return <EditListForm key={list.fields.slug} resource={list} />
 }

--- a/apps/ai-hero/src/app/(content)/posts/_components/edit-post-form.tsx
+++ b/apps/ai-hero/src/app/(content)/posts/_components/edit-post-form.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import * as React from 'react'
+import { useRouter } from 'next/navigation'
 import { ImageResourceUploader } from '@/components/image-uploader/image-resource-uploader'
 import { withResourceForm } from '@/components/resource-form/with-resource-form'
 import { useIsMobile } from '@/hooks/use-is-mobile'
@@ -30,6 +31,7 @@ export function EditPostForm({
 	listsLoader,
 }: EditPostFormProps) {
 	const isMobile = useIsMobile()
+	const router = useRouter()
 
 	// Handle either direct videoResource or resolve from loader
 	const resolvedVideoResource =
@@ -46,6 +48,11 @@ export function EditPostForm({
 		),
 		{
 			...postFormConfig,
+			onSave: async (resource, isSlugMismatch) => {
+				if (isSlugMismatch) {
+					router.push(`/posts/${resource.fields?.slug}/edit`)
+				}
+			},
 			customTools: [
 				{
 					id: 'media',

--- a/apps/ai-hero/src/app/(content)/posts/_components/edit-post-form.tsx
+++ b/apps/ai-hero/src/app/(content)/posts/_components/edit-post-form.tsx
@@ -48,8 +48,8 @@ export function EditPostForm({
 		),
 		{
 			...postFormConfig,
-			onSave: async (resource, isSlugMismatch) => {
-				if (isSlugMismatch) {
+			onSave: async (resource, hasNewSlug) => {
+				if (hasNewSlug) {
 					router.push(`/posts/${resource.fields?.slug}/edit`)
 				}
 			},

--- a/apps/ai-hero/src/components/resource-form/with-resource-form.tsx
+++ b/apps/ai-hero/src/components/resource-form/with-resource-form.tsx
@@ -144,7 +144,7 @@ export interface ResourceFormConfig<
 	autoUpdateResource?: (resource: Partial<T>) => Promise<T>
 
 	/** Optional callback after successful save */
-	onSave?: (resource: ContentResource) => Promise<void>
+	onSave?: (resource: ContentResource, isSlugMismatch: boolean) => Promise<void>
 
 	/**
 	 * Configuration for the body panel

--- a/apps/ai-hero/src/components/resource-form/with-resource-form.tsx
+++ b/apps/ai-hero/src/components/resource-form/with-resource-form.tsx
@@ -144,7 +144,7 @@ export interface ResourceFormConfig<
 	autoUpdateResource?: (resource: Partial<T>) => Promise<T>
 
 	/** Optional callback after successful save */
-	onSave?: (resource: ContentResource, isSlugMismatch: boolean) => Promise<void>
+	onSave?: (resource: ContentResource, hasNewSlug: boolean) => Promise<void>
 
 	/**
 	 * Configuration for the body panel

--- a/packages/ui/resources-crud/edit-resources-form-desktop.tsx
+++ b/packages/ui/resources-crud/edit-resources-form-desktop.tsx
@@ -39,7 +39,7 @@ export function EditResourcesFormDesktop({
 	toggleMdxPreview,
 	isShowingMdxPreview,
 }: {
-	onSave?: (resource: ContentResource) => Promise<void>
+	onSave?: (resource: ContentResource, isSlugMismatch: boolean) => Promise<void>
 	onPublish?: (resource: ContentResource) => Promise<void>
 	onArchive?: (resource: ContentResource) => Promise<void>
 	onUnPublish?: (resource: ContentResource) => Promise<void>
@@ -94,7 +94,10 @@ export function EditResourcesFormDesktop({
 		}
 
 		if (updatedResource && onSave) {
-			return await onSave(updatedResource)
+			const isSlugMismatch =
+				resource.fields.slug !== updatedResource.fields.slug
+
+			return await onSave(updatedResource, isSlugMismatch)
 		}
 	}
 

--- a/packages/ui/resources-crud/edit-resources-form-desktop.tsx
+++ b/packages/ui/resources-crud/edit-resources-form-desktop.tsx
@@ -39,7 +39,7 @@ export function EditResourcesFormDesktop({
 	toggleMdxPreview,
 	isShowingMdxPreview,
 }: {
-	onSave?: (resource: ContentResource, isSlugMismatch: boolean) => Promise<void>
+	onSave?: (resource: ContentResource, hasNewSlug: boolean) => Promise<void>
 	onPublish?: (resource: ContentResource) => Promise<void>
 	onArchive?: (resource: ContentResource) => Promise<void>
 	onUnPublish?: (resource: ContentResource) => Promise<void>
@@ -94,10 +94,9 @@ export function EditResourcesFormDesktop({
 		}
 
 		if (updatedResource && onSave) {
-			const isSlugMismatch =
-				resource.fields.slug !== updatedResource.fields.slug
+			const hasNewSlug = resource.fields.slug !== updatedResource.fields.slug
 
-			return await onSave(updatedResource, isSlugMismatch)
+			return await onSave(updatedResource, hasNewSlug)
 		}
 	}
 

--- a/packages/ui/resources-crud/edit-resources-form-mobile.tsx
+++ b/packages/ui/resources-crud/edit-resources-form-mobile.tsx
@@ -25,7 +25,7 @@ export function EditResourcesFormMobile({
 	user,
 	tools = [],
 }: {
-	onSave?: (resource: ContentResource, isSlugMismatch: boolean) => Promise<void>
+	onSave?: (resource: ContentResource, hasNewSlug: boolean) => Promise<void>
 	resource: ContentResource & {
 		fields: {
 			body?: string | null
@@ -51,10 +51,9 @@ export function EditResourcesFormMobile({
 	const onSubmit = async (values: z.infer<typeof resourceSchema>) => {
 		const updatedResource = await updateResource(values)
 		if (updatedResource && onSave) {
-			const isSlugMismatch =
-				resource.fields.slug !== updatedResource.fields.slug
+			const hasNewSlug = resource.fields.slug !== updatedResource.fields.slug
 
-			onSave(updatedResource, isSlugMismatch)
+			onSave(updatedResource, hasNewSlug)
 		}
 	}
 

--- a/packages/ui/resources-crud/edit-resources-form-mobile.tsx
+++ b/packages/ui/resources-crud/edit-resources-form-mobile.tsx
@@ -25,7 +25,7 @@ export function EditResourcesFormMobile({
 	user,
 	tools = [],
 }: {
-	onSave?: (resource: ContentResource) => Promise<void>
+	onSave?: (resource: ContentResource, isSlugMismatch: boolean) => Promise<void>
 	resource: ContentResource & {
 		fields: {
 			body?: string | null
@@ -51,7 +51,10 @@ export function EditResourcesFormMobile({
 	const onSubmit = async (values: z.infer<typeof resourceSchema>) => {
 		const updatedResource = await updateResource(values)
 		if (updatedResource && onSave) {
-			onSave(updatedResource)
+			const isSlugMismatch =
+				resource.fields.slug !== updatedResource.fields.slug
+
+			onSave(updatedResource, isSlugMismatch)
 		}
 	}
 


### PR DESCRIPTION
- Added slug mismatch detection in resource forms to handle routing correctly upon save.
- Updated the onSave callback in resource form configurations to include slug mismatch logic.
- Refactored ListForm to EditListForm for clarity in the edit context.

<img src="https://y.yarn.co/036ce436-895b-4e23-87dc-0fc9cf440790_text.gif" width="200" alt="gif">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced the editing experience for lists, posts, and resources. When saving changes, the system now verifies identifiers and seamlessly redirects you to the appropriate edit page, ensuring a consistent and streamlined workflow.
	- Introduced a new `EditListForm` component for improved list editing functionality.
	- Updated the `onSave` functionality across various components to include slug change detection, enhancing the editing process for resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->