### PR TITLE
feat(eai): sold out disable button

### DIFF
--- a/apps/epicdev-ai/src/app/(commerce)/products/[slug]/_components/pricing-widget.tsx
+++ b/apps/epicdev-ai/src/app/(commerce)/products/[slug]/_components/pricing-widget.tsx
@@ -37,6 +37,8 @@ export const PricingWidget: React.FC<{
 		commerceProps?.couponIdFromCoupon ||
 		(validCoupon ? couponFromCode?.id : undefined)
 
+	const isSoldOut = product.type === 'live' && (quantityAvailable || 0) <= 0
+
 	return (
 		<Pricing.Root
 			className="relative w-full"
@@ -64,7 +66,7 @@ export const PricingWidget: React.FC<{
 						</>
 					)}
 					<Pricing.BuyButton className="from-primary relative my-3 w-auto min-w-[260px] origin-bottom rounded-md bg-gradient-to-bl to-indigo-800 px-6 py-6 text-lg font-bold !text-white shadow-lg shadow-indigo-800/30 transition ease-in-out hover:hue-rotate-[8deg]">
-						{ctaLabel}
+						{isSoldOut ? 'Sold Out' : ctaLabel}
 					</Pricing.BuyButton>
 					<Pricing.GuaranteeBadge />
 					<Pricing.LiveRefundPolicy />

--- a/apps/epicdev-ai/src/app/(content)/[post]/_components/event-pricing.tsx
+++ b/apps/epicdev-ai/src/app/(content)/[post]/_components/event-pricing.tsx
@@ -193,12 +193,21 @@ export const BuyTicketButton: React.FC<
 }
 
 const BuyButton = ({ centered }: { centered?: boolean }) => {
-	const { formattedPrice, status } = usePricing()
+	const {
+		formattedPrice,
+		status,
+		product,
+		pricingData: { quantityAvailable },
+	} = usePricing()
 	const fullPrice = formattedPrice?.fullPrice || 0
 
 	const finalPrice = formattedPrice?.calculatedPrice || 0
 	const savings = fullPrice - finalPrice
 	const savingsPercentage = Math.round((savings / fullPrice) * 100)
+
+	const isSoldOut = Boolean(
+		product.type === 'live' && (quantityAvailable || 0) <= 0,
+	)
 
 	return (
 		<>
@@ -221,7 +230,7 @@ const BuyButton = ({ centered }: { centered?: boolean }) => {
 									<span className="font-semibold tabular-nums">
 										{formatUsd(finalPrice).dollars}
 									</span>
-									{savings > 0 && (
+									{savings > 0 && !isSoldOut && (
 										<>
 											<span className="ml-1 text-lg font-normal line-through opacity-90">
 												{formatUsd(fullPrice).dollars}
@@ -249,7 +258,7 @@ const BuyButton = ({ centered }: { centered?: boolean }) => {
 							centered && 'justify-center',
 						)}
 					>
-						{savings > 0 && (
+						{savings > 0 && !isSoldOut && (
 							<>
 								<span className="text-sm font-semibold">
 									Save {savingsPercentage}%{' '}
@@ -271,20 +280,24 @@ const BuyButton = ({ centered }: { centered?: boolean }) => {
 							)}
 						/>
 					</div>
-					<TeamToggle
-						className={cn(
-							'',
-							centered && 'w-full items-center justify-center text-center',
-						)}
-					/>
-					<div className="inline-flex w-full items-center justify-center">
-						<Pricing.LiveRefundPolicy
-							className={cn(
-								'inline-flex max-w-none pt-0 text-left',
-								centered && 'text-center',
-							)}
-						/>
-					</div>
+					{!isSoldOut && (
+						<>
+							<TeamToggle
+								className={cn(
+									'',
+									centered && 'w-full items-center justify-center text-center',
+								)}
+							/>
+							<div className="inline-flex w-full items-center justify-center">
+								<Pricing.LiveRefundPolicy
+									className={cn(
+										'inline-flex max-w-none pt-0 text-left',
+										centered && 'text-center',
+									)}
+								/>
+							</div>
+						</>
+					)}
 				</>
 			)}
 		</>

--- a/packages/commerce-next/src/pricing/pricing.tsx
+++ b/packages/commerce-next/src/pricing/pricing.tsx
@@ -773,7 +773,17 @@ const SaleCountdown = ({
 		props: CountdownRenderProps & { className?: string },
 	) => React.ReactElement
 }) => {
-	const { formattedPrice } = usePricing()
+	const {
+		formattedPrice,
+		product,
+		pricingData: { quantityAvailable },
+	} = usePricing()
+
+	const isSoldOut = Boolean(
+		product.type === 'live' && (quantityAvailable || 0) <= 0,
+	)
+
+	if (isSoldOut) return null
 
 	return formattedPrice?.defaultCoupon?.expires ? (
 		<Countdown

--- a/packages/commerce-next/src/pricing/pricing.tsx
+++ b/packages/commerce-next/src/pricing/pricing.tsx
@@ -449,22 +449,34 @@ const BuyButton = ({
 	asChild?: boolean
 }) => {
 	const Comp = asChild ? Slot : Button
-	const { formattedPrice, product, status } = usePricing()
+	const {
+		formattedPrice,
+		product,
+		status,
+		pricingData: { quantityAvailable },
+	} = usePricing()
+
+	const isSoldOut = Boolean(
+		product.type === 'live' && (quantityAvailable || 0) <= 0,
+	)
+
 	return (
 		<Comp
 			className={cn(
-				'bg-primary text-primary-foreground flex h-14 w-full items-center justify-center rounded px-4 py-4 text-center text-base font-medium ring-offset-1 transition ease-in-out disabled:cursor-wait',
+				'bg-primary text-primary-foreground flex h-14 w-full items-center justify-center rounded px-4 py-4 text-center text-base font-medium ring-offset-1 transition ease-in-out disabled:cursor-not-allowed disabled:opacity-50',
 				className,
 			)}
 			type="submit"
 			size="lg"
-			disabled={status === 'pending' || status === 'error'}
+			disabled={status === 'pending' || status === 'error' || isSoldOut}
 		>
 			{children
 				? children
-				: formattedPrice?.upgradeFromPurchaseId
-					? `Upgrade Now`
-					: product?.fields.action || `Buy Now`}
+				: isSoldOut
+					? 'Sold Out'
+					: formattedPrice?.upgradeFromPurchaseId
+						? `Upgrade Now`
+						: product?.fields.action || `Buy Now`}
 		</Comp>
 	)
 }


### PR DESCRIPTION
<img width="469" alt="Screenshot 2025-04-16 at 5 47 39 PM" src="https://github.com/user-attachments/assets/d55aa478-e3d8-4720-9f11-488b31ef9c30" />

![disable button](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExdWE5dG85ZXRiOTJpY2VneGg1aG53eTAzMHl5bDBoa3Q3cmd4d2NqcSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/l4pTqdlMJVeqbxXry/giphy.gif)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Buy buttons now display a "Sold Out" label and are disabled when live products are out of stock.
  - Savings information, countdowns, and refund policy details are hidden for sold-out products.
- **Style**
  - Disabled buy buttons now have updated styling for improved clarity when products are sold out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->