### PR TITLE
Update turbo.build to turborepo.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Course Builder is a real-time multiplayer CMS for building and deploying the opi
 
 The main Course Builder web application can be found in `apps/course-builder-web` and has further instructions in the readme.
 
-This is a monorepo managed by [Turborepo](https://turbo.build/)
+This is a monorepo managed by [Turborepo](https://turborepo.com/)
 
 ## Getting Started
 
@@ -20,6 +20,6 @@ All of the environment variables for various services are the biggest obstacle t
 
 `pnpm dev` from the root of the project will run all the packages in the monorepo in development watch mode. Very convenient.
 
-It does not run the `apps`. Those need to be individually started. 
+It does not run the `apps`. Those need to be individually started.
 
 Built by [Badass Courses 🍄🌈💀](https://badass.dev)


### PR DESCRIPTION
We updated the domain for Turborepo!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Turborepo URL in the README.
  - Removed a trailing space from a sentence for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->