### PR TITLE
fix(commerce): team quantity logic

### DIFF
--- a/.changeset/angry-towns-doubt.md
+++ b/.changeset/angry-towns-doubt.md
@@ -1,0 +1,5 @@
+---
+'@coursebuilder/core': patch
+---
+
+fix team quantity logic

--- a/apps/ai-hero/src/app/(content)/_components/video-player-overlay.tsx
+++ b/apps/ai-hero/src/app/(content)/_components/video-player-overlay.tsx
@@ -432,7 +432,7 @@ const VideoPlayerOverlay: React.FC<VideoPlayerOverlayProps> = ({
 		return (
 			<div
 				aria-live="polite"
-				className="relative z-40 flex aspect-video h-full w-full flex-col items-center justify-center p-5 py-8 text-lg"
+				className="relative z-40 flex h-full w-full flex-col items-center justify-center p-5 py-8 text-lg xl:aspect-video"
 			>
 				{pricingProps && <VideoOverlayWorkshopPricing {...pricingProps} />}
 			</div>

--- a/apps/ai-hero/src/app/(content)/workshops/_components/video-overlay-pricing-widget.tsx
+++ b/apps/ai-hero/src/app/(content)/workshops/_components/video-overlay-pricing-widget.tsx
@@ -33,7 +33,7 @@ export function VideoOverlayWorkshopPricing({
 	return product ? (
 		<PriceCheckProvider purchasedProductIds={purchasedProductIds}>
 			<Pricing.Root
-				className="mx-auto w-full max-w-md"
+				className=""
 				product={product}
 				couponId={couponId}
 				country={country}
@@ -44,6 +44,7 @@ export function VideoOverlayWorkshopPricing({
 					isLiveEvent: product.type === 'cohort',
 					isCohort: product.type === 'cohort',
 					teamQuantityLimit,
+					allowTeamPurchase: true,
 					isPPPEnabled: true,
 					cancelUrl: cancelUrl,
 				}}
@@ -53,16 +54,20 @@ export function VideoOverlayWorkshopPricing({
 				<Pricing.Product className="w-full">
 					<Pricing.ProductImage />
 					<Pricing.Details className="px-0 pt-0">
-						<Pricing.Name className="mb-5" />
-						<Pricing.LiveQuantity />
-						<Pricing.Price />
-						<Pricing.TeamToggle />
-						<Pricing.TeamQuantityInput />
-						<Pricing.BuyButton>Enroll Now</Pricing.BuyButton>
-						<Pricing.GuaranteeBadge />
-						<Pricing.LiveRefundPolicy />
-						<Pricing.SaleCountdown className="py-4" />
-						<Pricing.PPPToggle />
+						<div className="mx-auto flex w-full max-w-xs flex-col items-center justify-center">
+							<Pricing.Name className="font-medium" />
+							<Pricing.LiveQuantity />
+							<Pricing.Price className="mb-2 [&_div]:text-white" />
+							<Pricing.TeamToggle className="mb-2" />
+							<Pricing.TeamQuantityInput />
+							<Pricing.BuyButton className="text-lg font-semibold">
+								Enroll Now
+							</Pricing.BuyButton>
+							<Pricing.GuaranteeBadge />
+							<Pricing.LiveRefundPolicy className="max-w-none text-center" />
+							<Pricing.SaleCountdown className="py-4" />
+						</div>
+						<Pricing.PPPToggle className="mx-auto mt-3 w-full max-w-lg" />
 					</Pricing.Details>
 				</Pricing.Product>
 			</Pricing.Root>

--- a/apps/ai-hero/src/lib/pricing-query.ts
+++ b/apps/ai-hero/src/lib/pricing-query.ts
@@ -39,11 +39,22 @@ export async function getPricingData(
 				formattedPrice.upgradeFromPurchaseId,
 			)
 		: null
+
+	let resolvedQuantityAvailable: number
+	const dbProductQuantityAvailable = product?.quantityAvailable
+
+	if (dbProductQuantityAvailable === -1) {
+		resolvedQuantityAvailable = -1 // Product is unlimited
+	} else {
+		// Product has a finite quantity, subtract purchases
+		resolvedQuantityAvailable =
+			(dbProductQuantityAvailable || 0) - totalPurchases.length
+	}
+
 	return {
 		formattedPrice,
 		purchaseToUpgrade,
-		quantityAvailable:
-			(product?.quantityAvailable || 0) - totalPurchases.length,
+		quantityAvailable: resolvedQuantityAvailable,
 	}
 }
 

--- a/apps/epicdev-ai/src/lib/pricing-query.ts
+++ b/apps/epicdev-ai/src/lib/pricing-query.ts
@@ -39,11 +39,22 @@ export async function getPricingData(
 				formattedPrice.upgradeFromPurchaseId,
 			)
 		: null
+
+	let resolvedQuantityAvailable: number
+	const dbProductQuantityAvailable = product?.quantityAvailable
+
+	if (dbProductQuantityAvailable === -1) {
+		resolvedQuantityAvailable = -1 // Product is unlimited
+	} else {
+		// Product has a finite quantity, subtract purchases
+		resolvedQuantityAvailable =
+			(dbProductQuantityAvailable || 0) - totalPurchases.length
+	}
+
 	return {
 		formattedPrice,
 		purchaseToUpgrade,
-		quantityAvailable:
-			(product?.quantityAvailable || 0) - totalPurchases.length,
+		quantityAvailable: resolvedQuantityAvailable,
 	}
 }
 

--- a/packages/core/src/lib/pricing/pricing-state-machine.ts
+++ b/packages/core/src/lib/pricing/pricing-state-machine.ts
@@ -273,12 +273,29 @@ export const pricingMachine = setup({
 							isPPPActive: false,
 							isTeamPurchaseActive: ({ context }) =>
 								!context.isTeamPurchaseActive,
-							quantity: ({ context }) =>
-								context.isTeamPurchaseActive
-									? 1
-									: context.options.isLiveEvent
-										? Math.min(context.pricingData.quantityAvailable, 5)
-										: Math.min(context.options.teamQuantityLimit, 5),
+							quantity: ({ context }) => {
+								if (context.isTeamPurchaseActive) {
+									return 1
+								} else {
+									const defaultTeamSize = 5
+
+									if (context.options.isLiveEvent) {
+										if (context.pricingData.quantityAvailable === -1) {
+											return defaultTeamSize
+										} else {
+											return Math.min(
+												context.pricingData.quantityAvailable,
+												defaultTeamSize,
+											)
+										}
+									} else {
+										return Math.min(
+											context.options.teamQuantityLimit,
+											defaultTeamSize,
+										)
+									}
+								}
+							},
 						}),
 					],
 					guard: {


### PR DESCRIPTION
this fixes issue where team quantity input defaulted to `-15` 

<img src="https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExbDlsaWZyMHF2d2d5a29yZ3RyZG9xOXEwdmNwOTR0bjYzaHpqdGJvNCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/vKIcmjjbdpJmg/giphy.gif" width="250" alt="gif">

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved logic for handling team quantity selection and product availability, especially for live events and unlimited product quantities.
- **Style**
  - Updated layout and styling of the video overlay pricing widget for better visual organization and readability.
  - Adjusted aspect ratio styling of the video player overlay to be responsive on extra-large screens.
- **Chores**
  - Added metadata to track a fix related to team quantity handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->