### PR TITLE
feat(aih): add optional field to lesson metadata and form config

### DIFF
--- a/apps/ai-hero/src/app/(content)/workshops/_components/edit-workshop-lesson-form-metadata.tsx
+++ b/apps/ai-hero/src/app/(content)/workshops/_components/edit-workshop-lesson-form-metadata.tsx
@@ -23,12 +23,7 @@ import { z } from 'zod'
 import { VideoResource } from '@coursebuilder/core/schemas'
 import {
 	Button,
-	Dialog,
-	DialogContent,
-	DialogDescription,
-	DialogHeader,
-	DialogTitle,
-	DialogTrigger,
+	Checkbox,
 	FormDescription,
 	FormField,
 	FormItem,
@@ -184,6 +179,30 @@ export const LessonMetadataFormFields: React.FC<{
 				)}
 			/>
 			<TagField resource={lesson} showEditButton />
+			<FormField
+				control={form.control}
+				name="fields.optional"
+				render={({ field }) => (
+					<FormItem className="px-5">
+						<FormLabel className="flex items-center gap-2 text-lg font-bold">
+							<Checkbox
+								name={field.name}
+								ref={field.ref}
+								onBlur={field.onBlur}
+								disabled={field.disabled}
+								className="border-input"
+								checked={field.value ?? false}
+								onCheckedChange={(checked) => field.onChange(!!checked)}
+							/>{' '}
+							Optional
+						</FormLabel>
+						<FormDescription>
+							Optional lessons are not required to complete the workshop.
+						</FormDescription>
+						<FormMessage />
+					</FormItem>
+				)}
+			/>
 			{/* Solution Section */}
 			<div className="px-5">
 				<div className="flex items-center justify-between gap-2">

--- a/apps/ai-hero/src/app/(content)/workshops/_components/workshop-lesson-form-config.tsx
+++ b/apps/ai-hero/src/app/(content)/workshops/_components/workshop-lesson-form-config.tsx
@@ -56,6 +56,7 @@ export const createWorkshopLessonFormConfig = (
 			github: lesson?.fields?.github || '',
 			gitpod: lesson?.fields?.gitpod || '',
 			thumbnailTime: lesson?.fields?.thumbnailTime || 0,
+			optional: lesson?.fields?.optional || false,
 		},
 		tags: lesson?.tags || [],
 	}),
@@ -89,6 +90,7 @@ export const createWorkshopLessonFormConfig = (
 					visibility: resource.fields?.visibility || 'public',
 					github: resource.fields?.github || '',
 					thumbnailTime: resource.fields?.thumbnailTime || 0,
+					optional: resource.fields?.optional || false,
 				},
 				tags: resource.tags || [],
 			}
@@ -141,6 +143,7 @@ export const createWorkshopLessonFormConfig = (
 				visibility: resource.fields.visibility || 'public',
 				github: resource.fields.github || '',
 				thumbnailTime: resource.fields.thumbnailTime || 0,
+				optional: resource.fields.optional || false,
 			},
 			tags: resource.tags || [],
 		}

--- a/apps/ai-hero/src/lib/certificates.ts
+++ b/apps/ai-hero/src/lib/certificates.ts
@@ -112,6 +112,7 @@ async function hasUserCompletedAllLessons(
 			)
 	)
 	AND cr.type IN ('lesson', 'exercise')
+	AND (cr.fields->>'$.optional' IS NULL OR cr.fields->>'$.optional' = 'false')
 `)
 
 	const incompleteLessons = Number(results.rows[0]?.incomplete_lessons) || 0

--- a/apps/ai-hero/src/lib/lessons.ts
+++ b/apps/ai-hero/src/lib/lessons.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+import { optional, z } from 'zod'
 
 import {
 	ContentResourceResourceSchema,
@@ -28,6 +28,7 @@ export const LessonSchema = ContentResourceSchema.merge(
 			github: z.string().optional(),
 			gitpod: z.string().optional(),
 			thumbnailTime: z.number().nullish(),
+			optional: z.boolean().nullish().default(false),
 		}),
 		resources: z.array(ContentResourceResourceSchema).default([]).nullable(),
 		tags: PostTagsSchema,
@@ -47,6 +48,7 @@ export const LessonUpdateSchema = z.object({
 		visibility: PostVisibilitySchema.optional(),
 		github: z.string().nullish(),
 		thumbnailTime: z.number().nullish(),
+		optional: z.boolean().default(false),
 	}),
 	tags: PostTagsSchema,
 })


### PR DESCRIPTION
- Introduced an optional checkbox in the lesson metadata form to indicate if a lesson is required.
- Updated form configuration to handle the new optional field.
- Adjusted database queries to account for optional lessons in completion checks.
- Enhanced lesson schemas to include optional boolean with default value.

<img src="https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExcGg1ZGh1cXZoamlvdm55NXI0aWY5ZGRscnk4bnhic3huc2d0b2Y2MiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/qOxDo9jqmgv3DMwHaB/giphy.gif" width="250" alt="gif">