### PR TITLE
feat(aih): add transcript button when missing

### DIFF
--- a/apps/ai-hero/src/components/content/content-video-resource-field.tsx
+++ b/apps/ai-hero/src/components/content/content-video-resource-field.tsx
@@ -7,6 +7,7 @@ import { useRouter } from 'next/navigation'
 import { LessonPlayer } from '@/app/(content)/_components/lesson-player'
 import { NewLessonVideoForm } from '@/app/(content)/_components/new-lesson-video-form'
 import { SimplePostPlayer } from '@/app/(content)/posts/_components/post-player'
+import { reprocessTranscript } from '@/app/(content)/posts/[slug]/edit/actions'
 import Spinner from '@/components/spinner'
 import { env } from '@/env.mjs'
 import { useTranscript } from '@/hooks/use-transcript'
@@ -148,6 +149,7 @@ export const ContentVideoResourceField = <T extends ContentResourceBase>({
 		transcript,
 		setTranscript,
 		setIsProcessing: setIsTranscriptProcessing,
+		isProcessing: isTranscriptProcessing,
 		TranscriptDialog,
 	} = useTranscript({
 		videoResourceId: videoResource?.id,
@@ -299,6 +301,21 @@ export const ContentVideoResourceField = <T extends ContentResourceBase>({
 											Replace Video
 										</Button>
 										{showTranscript && transcript && TranscriptDialog}
+										{!transcript && !isTranscriptProcessing && (
+											<Button
+												variant="outline"
+												size={'sm'}
+												type="button"
+												onClick={() => {
+													setIsTranscriptProcessing(true)
+													reprocessTranscript({
+														videoResourceId: videoResource.id,
+													})
+												}}
+											>
+												Add Transcript
+											</Button>
+										)}
 										{thumbnailEnabled && (
 											<Tooltip delayDuration={0}>
 												<div className="flex items-center">


### PR DESCRIPTION
I ran into two lessons with transcripts that were missing and no way to order them through the UI. 

This adds a "Add Transcript" button when the transcript is not available and is not processing.

![gif](https://media1.giphy.com/media/l41YtZOb9EUABnuqA/giphy.gif?cid=1927fc1bmswl7j1u542ijm34ma4tywfba4fn9fx78147jonh&ep=v1_gifs_search&rid=giphy.gif&ct=g)