### PR TITLE
feat(aih): join discord cta on cohort module page

### DIFF
--- a/apps/ai-hero/src/app/(content)/workshops/[module]/page.tsx
+++ b/apps/ai-hero/src/app/(content)/workshops/[module]/page.tsx
@@ -22,6 +22,7 @@ import { db } from '@/db'
 import { contentResource } from '@/db/schema'
 import { env } from '@/env.mjs'
 import { getCachedMinimalWorkshop } from '@/lib/workshops-query'
+import { getProviders } from '@/server/auth'
 import { generateGridPattern } from '@/utils/generate-grid-pattern'
 import { getAbilityForResource } from '@/utils/get-current-ability-rules'
 import { getOGImageUrlForResource } from '@/utils/get-og-image-url-for-resource'
@@ -41,10 +42,9 @@ import {
 } from '@coursebuilder/ui'
 import { cn } from '@coursebuilder/ui/utils/cn'
 
+import { ConnectToDiscord } from '../_components/connect-to-discord'
 import WorkshopBreadcrumb from '../_components/workshop-breadcrumb'
 import WorkshopImage from '../_components/workshop-image'
-import { WorkshopPricing as WorkshopPricingClient } from '../_components/workshop-pricing'
-import { WorkshopPricing } from '../_components/workshop-pricing-server'
 
 type Props = {
 	params: Promise<{ module: string }>
@@ -100,6 +100,9 @@ export default async function ModulePage(props: Props) {
 		notFound()
 	}
 
+	const providers = getProviders()
+	const discordProvider = providers?.discord
+
 	const Links = ({ children }: { children?: React.ReactNode }) => {
 		return (
 			<div className="relative w-full grid-cols-6 items-center border-y md:grid">
@@ -135,6 +138,9 @@ export default async function ModulePage(props: Props) {
 								</DialogContent>
 							</Dialog>
 						</div>
+					</React.Suspense>
+					<React.Suspense fallback={null}>
+						<ConnectToDiscord discordProvider={discordProvider} />
 					</React.Suspense>
 				</div>
 				{children}

--- a/apps/ai-hero/src/app/(content)/workshops/_components/connect-to-discord.tsx
+++ b/apps/ai-hero/src/app/(content)/workshops/_components/connect-to-discord.tsx
@@ -1,0 +1,44 @@
+import { DiscordConnectButton } from '@/app/discord/discord-connect-button'
+import { db } from '@/db'
+import { users } from '@/db/schema'
+import { getServerAuthSession, Provider } from '@/server/auth'
+import { eq } from 'drizzle-orm'
+
+export const ConnectToDiscord = async ({
+	discordProvider,
+}: {
+	discordProvider?: Provider
+}) => {
+	const { session } = await getServerAuthSession()
+
+	if (!session?.user?.id) {
+		return null
+	}
+
+	const user = await db.query.users.findFirst({
+		where: eq(users.id, session?.user?.id),
+		with: {
+			accounts: true,
+		},
+	})
+
+	const discordConnected = Boolean(
+		user?.accounts.find((account: any) => account.provider === 'discord'),
+	)
+
+	if (discordConnected) {
+		return null
+	}
+
+	return (
+		<>
+			{discordProvider ? (
+				<div className="h-14 w-full rounded-none md:w-auto md:border-r">
+					<DiscordConnectButton discordProvider={discordProvider}>
+						Join Discord
+					</DiscordConnectButton>
+				</div>
+			) : null}
+		</>
+	)
+}

--- a/apps/ai-hero/src/app/discord/discord-connect-button.tsx
+++ b/apps/ai-hero/src/app/discord/discord-connect-button.tsx
@@ -9,14 +9,16 @@ import { Button } from '@coursebuilder/ui'
 
 export function DiscordConnectButton({
 	discordProvider,
+	children,
 }: {
 	discordProvider: { id: string; name: string }
+	children?: React.ReactNode
 }) {
 	return (
 		<Button
 			data-button=""
 			variant="ghost"
-			className="bg-black text-white"
+			className="h-full bg-black text-white"
 			onClick={() =>
 				signIn(discordProvider.id, {
 					callbackUrl: `${env.NEXT_PUBLIC_URL}/discord/redirect`,
@@ -29,7 +31,7 @@ export function DiscordConnectButton({
 				name="Discord"
 				size="20"
 			/>
-			Connect to Discord
+			{children || 'Connect to Discord'}
 		</Button>
 	)
 }


### PR DESCRIPTION
## logged in user with no discord
![image](https://github.com/user-attachments/assets/082d0626-7594-433d-b3e1-6779671f4ea8)
## logged in user with discord
![image](https://github.com/user-attachments/assets/a8331d51-6e69-4f20-b8ce-c148e6be8516)


![gif](https://media2.giphy.com/media/kHs1lBhZWaK5rj7lt3/giphy.gif?cid=1927fc1b17qgme7ll1trmrh0agtu5mmruckr3ff9a0hgzc1u&ep=v1_gifs_search&rid=giphy.gif&ct=g)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Discord connection prompt on workshop module pages, allowing authenticated users to join Discord if they haven't already linked their account.

- **Enhancements**
  - The Discord connect button now supports customizable labels, improving flexibility in how prompts are displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->