### PR TITLE
feat(eai): add attendee instructions to event form and page

### DIFF
--- a/apps/epicdev-ai/src/app/(content)/events/[slug]/edit/_components/edit-event-form.tsx
+++ b/apps/epicdev-ai/src/app/(content)/events/[slug]/edit/_components/edit-event-form.tsx
@@ -149,6 +149,7 @@ const eventFormConfig: ResourceFormConfig<Event, typeof EventSchema> = {
 					url: getOGImageUrlForResource(event as Event),
 				},
 				details: event?.fields?.details || '',
+				attendeeInstructions: event?.fields?.attendeeInstructions || '',
 			},
 			// Handle resourceProducts (specific to EventSchema merge)
 			resourceProducts: event?.resourceProducts || [],
@@ -346,6 +347,76 @@ const EventFormFields = ({
 			<MetadataFieldState form={form} />
 			<MetadataFieldVisibility form={form} />
 			<TagField resource={resource} showEditButton />
+
+			<FormField
+				control={form.control}
+				name="fields.startsAt"
+				render={({ field }) => (
+					<FormItem className="px-5">
+						<FormLabel className="text-lg font-bold">Starts at</FormLabel>
+						<DateTimePicker
+							aria-label="Starts At"
+							{...field}
+							value={
+								!!field.value
+									? parseAbsolute(
+											new Date(field.value).toISOString(),
+											'America/Los_Angeles',
+										)
+									: null
+							}
+							onChange={(date) => {
+								field.onChange(
+									!!date ? date.toDate('America/Los_Angeles') : null,
+								)
+							}}
+							shouldCloseOnSelect={false}
+							granularity="minute"
+						/>
+						<FormMessage />
+					</FormItem>
+				)}
+			/>
+			<FormField
+				control={form.control}
+				name="fields.endsAt"
+				render={({ field }) => (
+					<FormItem className="px-5">
+						<FormLabel className="text-lg font-bold">Ends at</FormLabel>
+						<DateTimePicker
+							aria-label="Ends At"
+							{...field}
+							value={
+								!!field.value
+									? parseAbsolute(
+											new Date(field.value).toISOString(),
+											'America/Los_Angeles',
+										)
+									: null
+							}
+							onChange={(date) => {
+								field.onChange(
+									!!date ? date.toDate('America/Los_Angeles') : null,
+								)
+							}}
+							shouldCloseOnSelect={false}
+							granularity="minute"
+						/>
+						<FormMessage />
+					</FormItem>
+				)}
+			/>
+			<FormField
+				control={form.control}
+				name="fields.timezone"
+				render={({ field }) => (
+					<FormItem className="px-5">
+						<FormLabel className="text-lg font-bold">Timezone</FormLabel>
+						<Input {...field} readOnly disabled value={field.value || ''} />
+						<FormMessage />
+					</FormItem>
+				)}
+			/>
 			<Dialog>
 				<DialogTrigger asChild>
 					<div className="px-5">
@@ -396,75 +467,60 @@ const EventFormFields = ({
 				</DialogContent>
 			</Dialog>
 
-			<FormField
-				control={form.control}
-				name="fields.startsAt"
-				render={({ field }) => (
-					<FormItem className="px-5">
-						<FormLabel className="text-lg font-bold">Starts At:</FormLabel>
-						<DateTimePicker
-							aria-label="Starts At"
-							{...field}
-							value={
-								!!field.value
-									? parseAbsolute(
-											new Date(field.value).toISOString(),
-											'America/Los_Angeles',
-										)
-									: null
-							}
-							onChange={(date) => {
-								field.onChange(
-									!!date ? date.toDate('America/Los_Angeles') : null,
-								)
-							}}
-							shouldCloseOnSelect={false}
-							granularity="minute"
+			<Dialog>
+				<DialogTrigger asChild>
+					<div className="px-5">
+						<FormLabel className="inline-flex items-center text-lg font-bold">
+							Attendee Instructions
+						</FormLabel>
+						<FormDescription>
+							Instructions for attendees who have registered for this event.
+							Displayed on the event page.
+						</FormDescription>
+						<Textarea
+							readOnly
+							value={form.watch('fields.attendeeInstructions') ?? ''}
 						/>
-						<FormMessage />
-					</FormItem>
-				)}
-			/>
-			<FormField
-				control={form.control}
-				name="fields.endsAt"
-				render={({ field }) => (
-					<FormItem className="px-5">
-						<FormLabel className="text-lg font-bold">Ends At:</FormLabel>
-						<DateTimePicker
-							aria-label="Ends At"
-							{...field}
-							value={
-								!!field.value
-									? parseAbsolute(
-											new Date(field.value).toISOString(),
-											'America/Los_Angeles',
-										)
-									: null
-							}
-							onChange={(date) => {
-								field.onChange(
-									!!date ? date.toDate('America/Los_Angeles') : null,
-								)
-							}}
-							shouldCloseOnSelect={false}
-							granularity="minute"
-						/>
-						<FormMessage />
-					</FormItem>
-				)}
-			/>
-			<FormField
-				control={form.control}
-				name="fields.timezone"
-				render={({ field }) => (
-					<FormItem className="px-5">
-						<FormLabel className="text-lg font-bold">Timezone:</FormLabel>
-						<Input {...field} readOnly disabled value={field.value || ''} />
-						<FormMessage />
-					</FormItem>
-				)}
-			/>
+					</div>
+				</DialogTrigger>
+				<DialogContent className="scrollbar-thin max-h-[500px] max-w-screen-md">
+					<DialogHeader>
+						<DialogTitle className=" inline-flex items-center text-lg font-bold">
+							Attendee Instructions
+						</DialogTitle>
+						<DialogDescription>
+							Instructions for attendees who have registered for this event.
+							Displayed on the event page. Markdown is supported.
+						</DialogDescription>
+					</DialogHeader>
+					<FormField
+						control={form.control}
+						name="fields.attendeeInstructions"
+						render={({ field }) => (
+							<FormItem>
+								<MarkdownEditor
+									theme={
+										(theme === 'dark'
+											? CourseBuilderEditorThemeDark
+											: CourseBuilderEditorThemeLight) ||
+										CourseBuilderEditorThemeDark
+									}
+									extensions={[EditorView.lineWrapping]}
+									height="300px"
+									maxHeight="500px"
+									onChange={(value) => {
+										form.setValue('fields.attendeeInstructions', value)
+									}}
+									value={field.value?.toString()}
+								/>
+
+								<FormMessage />
+							</FormItem>
+						)}
+					/>
+				</DialogContent>
+			</Dialog>
+
 			<FormField
 				control={form.control}
 				name="fields.description"

--- a/apps/epicdev-ai/src/app/(content)/events/[slug]/page.tsx
+++ b/apps/epicdev-ai/src/app/(content)/events/[slug]/page.tsx
@@ -17,9 +17,15 @@ import { getPricingData } from '@/lib/pricing-query'
 import { getServerAuthSession } from '@/server/auth'
 import { compileMDX } from '@/utils/compile-mdx'
 import { getOGImageUrlForResource } from '@/utils/get-og-image-url-for-resource'
+import {
+	CheckCircleIcon,
+	DocumentCurrencyDollarIcon,
+	DocumentTextIcon,
+} from '@heroicons/react/24/outline'
 import { formatInTimeZone } from 'date-fns-tz'
 import { count, eq } from 'drizzle-orm'
-import { CheckCircle, File } from 'lucide-react'
+import { CheckCircle, File, StickyNote } from 'lucide-react'
+import Markdown from 'react-markdown'
 import { Event as EventMetaSchema, Ticket } from 'schema-dts'
 
 import { propsForCommerce } from '@coursebuilder/core/pricing/props-for-commerce'
@@ -219,6 +225,8 @@ export default async function EventPage(props: {
 		},
 	)
 
+	const hasPurchasedCurrentProduct = eventProps.hasPurchasedCurrentProduct
+
 	return (
 		<LayoutClient withContainer>
 			<EventMetadata
@@ -275,6 +283,17 @@ export default async function EventPage(props: {
 			</header>
 			<main className="flex w-full grid-cols-12 flex-col pb-16 lg:grid lg:gap-12 ">
 				<div className="col-span-8 flex w-full flex-col">
+					{event.fields.attendeeInstructions && (
+						<div className="dark:bg-card dark:border-foreground/10 mb-8 flex flex-col gap-1 rounded-md border bg-white p-6 text-left font-medium shadow-xl">
+							<p className="inline-flex items-center font-semibold">
+								<DocumentTextIcon className="mr-1 size-5 text-teal-600 dark:text-teal-400" />{' '}
+								Attendee Instructions
+							</p>
+							<Markdown className="prose dark:prose-invert mt-2">
+								{event.fields.attendeeInstructions}
+							</Markdown>
+						</div>
+					)}
 					{hasVideo && <PlayerContainer event={event} />}
 					<Contributor className="justify-center sm:justify-start" />
 					<article className="prose sm:prose-lg prose-headings:text-balance w-full max-w-none py-8">
@@ -283,31 +302,48 @@ export default async function EventPage(props: {
 				</div>
 
 				<EventSidebar>
-					{eventProps.hasPurchasedCurrentProduct ? (
-						<div className="dark:border-b-foreground/10 flex flex-col gap-1 border-b p-6 text-left font-medium">
-							<p>
-								<CheckCircle className="inline-block size-4 text-teal-600 dark:text-teal-400" />{' '}
-								You have purchased a ticket to this event. See you on{' '}
-								{eventDate}.{' '}
-								<span role="img" aria-label="Waving hand">
-									👋
-								</span>
-							</p>
-							{eventProps?.existingPurchase?.merchantChargeId && (
-								<p>
-									<File className="text-primary inline-block size-4" />{' '}
-									<Link
-										className="text-primary underline underline-offset-2"
-										href={`/invoices/${eventProps.existingPurchase?.merchantChargeId}`}
-									>
-										Invoice
-									</Link>
+					{hasPurchasedCurrentProduct ? (
+						<>
+							<div
+								className={cn(
+									'dark:border-b-foreground/10 flex flex-col gap-1 border-b p-6 text-left font-medium',
+								)}
+							>
+								<p className="font-semibold">
+									<CheckCircleIcon className="inline-block size-5 text-teal-600 dark:text-teal-400" />{' '}
+									You have purchased a ticket to this event. See you on{' '}
+									{eventDate}.{' '}
+									<span role="img" aria-label="Waving hand">
+										👋
+									</span>
 								</p>
-							)}
-						</div>
+								{eventProps?.existingPurchase?.merchantChargeId && (
+									<p>
+										<DocumentCurrencyDollarIcon className="text-primary inline-block size-5" />{' '}
+										<Link
+											className="text-primary underline underline-offset-2"
+											href={`/invoices/${eventProps.existingPurchase?.merchantChargeId}`}
+										>
+											Invoice
+										</Link>
+									</p>
+								)}
+							</div>
+							{/* {event.fields.attendeeInstructions && (
+								<div className="dark:border-b-foreground/10 flex flex-col gap-1 border-b p-6 text-left font-medium">
+									<p className="inline-flex items-center font-semibold">
+										<DocumentTextIcon className="mr-1 size-5 text-teal-600 dark:text-teal-400" />{' '}
+										Attendee Instructions
+									</p>
+									<Markdown className="prose dark:prose-invert">
+										{event.fields.attendeeInstructions}
+									</Markdown>
+								</div>
+							)} */}
+						</>
 					) : null}
 					<EventDetails event={event} />
-					{!eventProps.hasPurchasedCurrentProduct && (
+					{!hasPurchasedCurrentProduct && (
 						<EventPricingWidgetContainer {...eventProps} />
 					)}
 				</EventSidebar>

--- a/apps/epicdev-ai/src/lib/events.ts
+++ b/apps/epicdev-ai/src/lib/events.ts
@@ -13,6 +13,7 @@ export const EventFieldsSchema = z.object({
 	startsAt: z.string().datetime().nullable().optional(),
 	endsAt: z.string().datetime().nullable().optional(),
 	timezone: z.string().default('America/Los_Angeles').nullish(),
+	attendeeInstructions: z.string().nullable().optional(),
 })
 
 /**


### PR DESCRIPTION
<img src="https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExZDV5dWxoMXU5ZGFtMWhvN2xyMnJqMjlqejFlYTBuMDJyNXd1ZXpnYyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/iRzOvNksn2Egw/giphy.gif" width="250" alt="gif">

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for attendee instructions in event forms, allowing organizers to provide additional guidance for attendees.
  - Introduced a Markdown editor and preview for attendee instructions within the event editing interface.
  - Displayed attendee instructions above the video player on the event page when available.

- **Enhancements**
  - Updated event page sidebar with new icons and improved styling for purchase confirmation and invoice links.
  - Improved label formatting for event form fields by removing trailing colons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->