### PR TITLE
feat(ew): add Tips page and enhance post creation modal

### DIFF
--- a/apps/epic-web/src/app/admin/layout.tsx
+++ b/apps/epic-web/src/app/admin/layout.tsx
@@ -3,6 +3,7 @@ import LayoutClient from '@/components/layout-client'
 import {
 	FileText,
 	Flag,
+	Lightbulb,
 	ListChecks,
 	Mail,
 	TagIcon,
@@ -33,6 +34,10 @@ const AdminLayout = async ({
 									<NavItem href="/admin/posts">
 										<FileText className="h-4 w-4" />
 										Posts
+									</NavItem>
+									<NavItem href="/admin/tips">
+										<Lightbulb className="h-4 w-4" />
+										Tips
 									</NavItem>
 								</li>
 							</ul>

--- a/apps/epic-web/src/app/admin/posts/_components/create-post-modal.tsx
+++ b/apps/epic-web/src/app/admin/posts/_components/create-post-modal.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import * as React from 'react'
 import { PostType } from '@/lib/posts'
 import { FilePlus2, Loader2 } from 'lucide-react'
@@ -99,7 +101,13 @@ export function CreatePostModal({
 		setIsProcessing(true)
 		if (onResourceCreated) {
 			await onResourceCreated(resource)
-			setIsProcessing(false)
+		}
+		// Reset processing state and allow modal to be closed
+		setIsProcessing(false)
+		// Auto-close the dialog after successful creation when no custom
+		// onResourceCreated handler is provided
+		if (!onResourceCreated) {
+			setIsOpen(false)
 		}
 	}
 

--- a/apps/epic-web/src/app/admin/tips/page.tsx
+++ b/apps/epic-web/src/app/admin/tips/page.tsx
@@ -9,12 +9,15 @@ import { Lightbulb } from 'lucide-react'
 
 import { CreatePostModal } from '../posts/_components/create-post-modal'
 
+/**
+ * Admin page for managing tips.
+ * Requires 'manage all' permissions to access.
+ */
 export default async function TipsIndexPage() {
 	const { ability } = await getServerAuthSession()
 	if (ability.cannot('manage', 'all')) {
 		notFound()
 	}
-
 	const allTips = await getAllTips()
 
 	return (

--- a/apps/epic-web/src/app/admin/tips/page.tsx
+++ b/apps/epic-web/src/app/admin/tips/page.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import type { Post } from '@/lib/posts'
+import { getAllTips } from '@/lib/posts-query'
+import { getServerAuthSession } from '@/server/auth'
+import { cn } from '@/utils/cn'
+import { Lightbulb } from 'lucide-react'
+
+import { CreatePostModal } from '../posts/_components/create-post-modal'
+
+export default async function TipsIndexPage() {
+	const { ability } = await getServerAuthSession()
+	if (ability.cannot('manage', 'all')) {
+		notFound()
+	}
+
+	const allTips = await getAllTips()
+
+	return (
+		<main className="flex w-full justify-between p-10">
+			<div className="mx-auto flex w-full max-w-4xl flex-col gap-5">
+				<div className="mb-5 flex w-full items-center justify-between">
+					<h1 className="fluid-3xl font-heading font-bold">Tips</h1>
+
+					<CreatePostModal
+						availableResourceTypes={['tip']}
+						defaultResourceType="tip"
+						topLevelResourceTypes={['post']}
+					/>
+				</div>
+				<ul className="divide-border flex flex-col divide-y">
+					{allTips.map((tip, i) => {
+						return (
+							<TipTeaser
+								i={i}
+								article={tip}
+								key={tip.id}
+								className="flex w-full items-center py-4"
+							/>
+						)
+					})}
+				</ul>
+			</div>
+		</main>
+	)
+}
+
+const TipTeaser: React.FC<{
+	article: Post
+	i?: number
+	className?: string
+}> = ({ article, className, i }) => {
+	const title = article.fields.title
+
+	return (
+		<li className={cn('', className)}>
+			<Link
+				href={`/admin/posts/${article.fields.slug}/edit`}
+				passHref
+				className="fluid-lg flex w-full items-center gap-3 py-5"
+			>
+				<Lightbulb className="text-muted-foreground h-4 w-4" /> {title}
+			</Link>
+		</li>
+	)
+}

--- a/apps/epic-web/src/app/admin/tips/page.tsx
+++ b/apps/epic-web/src/app/admin/tips/page.tsx
@@ -37,7 +37,7 @@ export default async function TipsIndexPage() {
 						return (
 							<TipTeaser
 								i={i}
-								article={tip}
+								tip={tip}
 								key={tip.id}
 								className="flex w-full items-center py-4"
 							/>
@@ -49,17 +49,24 @@ export default async function TipsIndexPage() {
 	)
 }
 
+/**
+ * Displays a single tip entry inside the Tips admin list.
+ *
+ * @param tip - The tip resource to display.
+ * @param i - Optional index of the tip in the list (unused currently, but handy for future needs).
+ * @param className - Optional additional CSS classes to apply to the list item element.
+ */
 const TipTeaser: React.FC<{
-	article: Post
+	tip: Post
 	i?: number
 	className?: string
-}> = ({ article, className, i }) => {
-	const title = article.fields.title
+}> = ({ tip, className, i }) => {
+	const title = tip.fields.title
 
 	return (
 		<li className={cn('', className)}>
 			<Link
-				href={`/admin/posts/${article.fields.slug}/edit`}
+				href={`/admin/posts/${tip.fields.slug}/edit`}
 				passHref
 				className="fluid-lg flex w-full items-center gap-3 py-5"
 			>

--- a/apps/epic-web/src/lib/posts-query.ts
+++ b/apps/epic-web/src/lib/posts-query.ts
@@ -91,7 +91,7 @@ export async function getAllTips(): Promise<Post[]> {
 		const posts = await db.query.contentResource.findMany({
 			where: and(
 				eq(contentResource.type, 'post'),
-				eq(sql`JSON_EXTRACT (${contentResource.fields}, "$.postType")`, 'tip')
+				eq(sql`JSON_EXTRACT (${contentResource.fields}, "$.postType")`, 'tip'),
 			),
 			orderBy: desc(contentResource.createdAt),
 			with: {

--- a/apps/epic-web/src/lib/resource-types.ts
+++ b/apps/epic-web/src/lib/resource-types.ts
@@ -5,7 +5,7 @@ import { z } from 'zod'
  */
 export const PostTypeSchema = z.union([
 	z.literal('article'),
-
+	z.literal('tip'),
 	z.literal('event'),
 ])
 
@@ -17,7 +17,7 @@ export type PostType = z.infer<typeof PostTypeSchema>
 /**
  * Valid post subtypes - only the 'post' resource type has subtypes
  */
-export const POST_SUBTYPES: (PostType | string)[] = ['article', 'event']
+export const POST_SUBTYPES: (PostType | string)[] = ['article', 'tip', 'event']
 
 /**
  * Schema defining all top-level resource types in the system
@@ -70,4 +70,4 @@ export const RESOURCE_TYPES_WITH_VIDEO: ResourceType[] = ['lesson']
 /**
  * Post types that support video content
  */
-export const POST_TYPES_WITH_VIDEO: (PostType | string)[] = ['article']
+export const POST_TYPES_WITH_VIDEO: (PostType | string)[] = ['article', 'tip']

--- a/apps/epic-web/src/lib/resources.ts
+++ b/apps/epic-web/src/lib/resources.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import {
 	AnyResourceTypeSchema,
 	POST_SUBTYPES,
+	POST_TYPES_WITH_VIDEO,
 	PostTypeSchema,
 	RESOURCE_TYPES_WITH_VIDEO,
 	ResourceType,
@@ -54,8 +55,7 @@ export function supportsVideo(type: string): boolean {
 	}
 
 	// Check if it's a post subtype that supports video
-	const postTypesWithVideo = ['article']
-	return postTypesWithVideo.includes(type)
+	return POST_TYPES_WITH_VIDEO.includes(type)
 }
 
 /**

--- a/apps/epic-web/src/utils/resource-paths.ts
+++ b/apps/epic-web/src/utils/resource-paths.ts
@@ -57,7 +57,7 @@ const resourcePaths: Record<string, ResourcePathConfig> = {
 		},
 	},
 	post: {
-		edit: (slug) => `/posts/${slug}/edit`,
+		edit: (slug) => `/admin/posts/${slug}/edit`,
 		view: (slug) => `/${slug}`,
 	},
 	workshop: {


### PR DESCRIPTION
![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExZWRidXgyd3Jyam1lMHdia2RyNXJrNGE0YzI5MTVxeHo0aXN5dXpxaCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/wWSl4a57OttGZllmNS/giphy.gif)

- Introduced a new Tips page for managing tips, including a modal for creating new tips.
- Updated the layout to include a navigation item for Tips.
- Enhanced the CreatePostModal to auto-close after successful creation when no custom handler is provided.
- Added functionality to fetch and filter tips in the posts-query library.
- Updated resource types to include 'tip' as a valid post subtype.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a "Tips" section in the admin sidebar for easier access.
	- Added a dedicated admin page to view and manage tip posts, including listing and creation capabilities.
- **Improvements**
	- Tip posts now support video content, similar to articles.
	- Updated post edit URLs to use a consistent admin route structure.
- **Bug Fixes**
	- Improved modal behavior when creating posts, ensuring dialogs close automatically when appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->