### PR TITLE
feat(utils-resource): add tip path generation tests and update resource paths configuration

### DIFF
--- a/packages/utils-resource/src/resource-paths.test.ts
+++ b/packages/utils-resource/src/resource-paths.test.ts
@@ -43,6 +43,13 @@ describe('getResourcePath', () => {
 			)
 		})
 
+		test('should generate tip paths', () => {
+			expect(getResourcePath('tip', 'my-tip')).toBe('/my-tip')
+			expect(getResourcePath('tip', 'my-tip', 'edit')).toBe(
+				'/posts/my-tip/edit',
+			)
+		})
+
 		test('should generate workshop paths', () => {
 			expect(getResourcePath('workshop', 'my-workshop')).toBe(
 				'/workshops/my-workshop',

--- a/packages/utils-resource/src/resource-paths.ts
+++ b/packages/utils-resource/src/resource-paths.ts
@@ -77,6 +77,10 @@ const resourcePaths: Record<string, ResourcePathConfig> = {
 		edit: (slug) => `/posts/${slug}/edit`,
 		view: (slug) => `/${slug}`,
 	},
+	tip: {
+		edit: (slug) => `/posts/${slug}/edit`,
+		view: (slug) => `/${slug}`,
+	},
 	workshop: {
 		edit: (slug) => `/workshops/${slug}/edit`,
 		view: (slug) => `/workshops/${slug}`,


### PR DESCRIPTION
- Introduced tests for generating tip paths in resource-paths.test.ts
- Updated resource-paths.ts to include tip path configurations for edit and view actions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for generating paths for the "tip" resource type, allowing users to view and edit tips using consistent URL patterns.

* **Tests**
  * Added new test cases to verify correct path generation for the "tip" resource type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->