### PR TITLE
feat(eai): integrate exercises into "next up" logic

### DIFF
--- a/apps/epicdev-ai/src/app/(content)/_components/authed-video-player.tsx
+++ b/apps/epicdev-ai/src/app/(content)/_components/authed-video-player.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react'
 import { use } from 'react'
-import { useRouter, useSearchParams } from 'next/navigation'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { useMuxPlayer } from '@/hooks/use-mux-player'
 import {
 	handleTextTrackChange,
@@ -82,9 +82,15 @@ export function AuthedVideoPlayer({
 
 	const navigation = useWorkshopNavigation()
 
+	const pathname = usePathname()
 	const { nextResource, prevResource } = getAdjacentWorkshopResources(
 		navigation,
 		currentResource.id,
+		pathname.endsWith('/exercise')
+			? 'exercise'
+			: pathname.endsWith('/solution')
+				? 'solution'
+				: 'lesson',
 	)
 
 	const isProblemLesson = Boolean(

--- a/apps/epicdev-ai/src/app/(content)/_components/authed-video-player.tsx
+++ b/apps/epicdev-ai/src/app/(content)/_components/authed-video-player.tsx
@@ -225,7 +225,10 @@ async function handleOnVideoEnded({
 		if (bingeMode && nextResource && playerRef?.current) {
 			dispatchVideoPlayerOverlay({ type: 'LOADING' })
 			// playerRef.current.playbackId = nextLessonPlaybackId
-			if (nextResource.type !== 'solution') {
+			if (
+				nextResource.type !== 'solution' &&
+				nextResource.type !== 'exercise'
+			) {
 				console.log(
 					'setting lesson complete',
 					isSolution ? prevResource : currentResource,

--- a/apps/epicdev-ai/src/app/(content)/_components/lesson-controls-next-up.tsx
+++ b/apps/epicdev-ai/src/app/(content)/_components/lesson-controls-next-up.tsx
@@ -1,0 +1,92 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import type { Lesson } from '@/lib/lessons'
+import { getAdjacentWorkshopResources } from '@/utils/get-adjacent-workshop-resources'
+import { ArrowRight } from 'lucide-react'
+
+import { Button } from '@coursebuilder/ui'
+import { getResourcePath } from '@coursebuilder/utils-resource/resource-paths'
+
+import { useWorkshopNavigation } from '../workshops/_components/workshop-navigation-provider'
+
+const LessonControlsNextUp = ({ currentLesson }: { currentLesson: Lesson }) => {
+	const navigation = useWorkshopNavigation()
+	const pathname = usePathname()
+
+	// Determine current context from URL
+	const getCurrentContext = () => {
+		if (pathname.endsWith('/exercise')) {
+			return 'exercise'
+		} else if (pathname.endsWith('/solution')) {
+			return 'solution'
+		} else {
+			return 'lesson' // or could be 'post', but for completion logic, treat as lesson
+		}
+	}
+
+	if (!navigation) return null
+
+	const { nextResource, isExerciseNext, isSolutionNext } =
+		getAdjacentWorkshopResources(
+			navigation,
+			currentLesson.id,
+			getCurrentContext(),
+		)
+
+	if (!nextResource) return null
+
+	return (
+		<>
+			{isSolutionNext && (
+				<Button
+					asChild
+					variant="outline"
+					className="hover:bg-muted/50 border-l-border h-full rounded-none border-0 border-l bg-transparent"
+				>
+					<Link
+						href={getResourcePath(
+							'solution',
+							currentLesson.fields.slug,
+							'view',
+							{
+								parentType: 'workshop',
+								parentSlug: navigation.slug,
+							},
+						)}
+						prefetch
+					>
+						Solution
+						<ArrowRight className="text-muted-foreground ml-2 h-4 w-4" />
+					</Link>
+				</Button>
+			)}
+			{isExerciseNext && (
+				<Button
+					asChild
+					variant="outline"
+					className="hover:bg-muted/50 border-l-border h-full rounded-none border-0 border-l bg-transparent"
+				>
+					<Link
+						href={getResourcePath(
+							'exercise',
+							currentLesson.fields.slug,
+							'view',
+							{
+								parentType: 'workshop',
+								parentSlug: navigation.slug,
+							},
+						)}
+						prefetch
+					>
+						Exercise
+						<ArrowRight className="text-muted-foreground ml-2 h-4 w-4" />
+					</Link>
+				</Button>
+			)}
+		</>
+	)
+}
+
+export default LessonControlsNextUp

--- a/apps/epicdev-ai/src/app/(content)/_components/lesson-controls.tsx
+++ b/apps/epicdev-ai/src/app/(content)/_components/lesson-controls.tsx
@@ -12,6 +12,7 @@ import type { AbilityForResource } from '@coursebuilder/utils-auth/current-abili
 
 import { CopyProblemPromptButton } from '../workshops/_components/copy-problem-prompt-button'
 import { AutoPlayToggle } from './autoplay-toggle'
+import LessonControlsNextUp from './lesson-controls-next-up'
 import { ModuleLessonProgressToggle } from './module-lesson-progress-toggle'
 
 export const LessonControls = async ({
@@ -44,6 +45,9 @@ export const LessonControls = async ({
 
 	const hasSolution = lesson.resources?.some(
 		(resource) => resource.resource.type === 'solution',
+	)
+	const hasExercise = lesson.resources?.some(
+		(resource) => resource.resource.type === 'exercise',
 	)
 
 	const isProblemLesson = lesson.type === 'lesson' && hasSolution
@@ -80,18 +84,7 @@ export const LessonControls = async ({
 					</Button>
 				)}
 			</div>
-			{isProblemLesson && (
-				<Button
-					asChild
-					variant="outline"
-					className="hover:bg-muted/50 border-l-border h-full rounded-none border-0 border-l bg-transparent"
-				>
-					<Link href={`${lesson.fields.slug}/solution`} prefetch>
-						Solution
-						<ArrowRight className="text-muted-foreground ml-2 h-4 w-4" />
-					</Link>
-				</Button>
-			)}
+			{isProblemLesson && <LessonControlsNextUp currentLesson={lesson} />}
 			<React.Suspense fallback={null}>
 				{(session?.user || ckSubscriber) &&
 				((lesson.type === 'lesson' && !isProblemLesson) ||

--- a/apps/epicdev-ai/src/app/(content)/_components/video-player-overlay.tsx
+++ b/apps/epicdev-ai/src/app/(content)/_components/video-player-overlay.tsx
@@ -70,7 +70,15 @@ export const CompletedLessonOverlay: React.FC<{
 		nextResource: nextLesson,
 		prevResource: prevLesson,
 		isSolutionNext,
-	} = getAdjacentWorkshopResources(workshopNavigation, resource?.id as string)
+	} = getAdjacentWorkshopResources(
+		workshopNavigation,
+		resource?.id as string,
+		usePathname().endsWith('/exercise')
+			? 'exercise'
+			: usePathname().endsWith('/solution')
+				? 'solution'
+				: 'lesson',
+	)
 
 	const { dispatch: dispatchVideoPlayerOverlay } = useVideoPlayerOverlay()
 	const { moduleProgress } = useModuleProgress()
@@ -300,6 +308,11 @@ const ContinueButton: React.FC<{
 					if (nextResource.type === 'solution') {
 						return router.push(
 							`/${pluralize(moduleType)}/${moduleNavigation.slug}/${resource?.fields?.slug}/solution`,
+						)
+					}
+					if (nextResource.type === 'exercise') {
+						return router.push(
+							`/${pluralize(moduleType)}/${moduleNavigation.slug}/${resource?.fields?.slug}/exercise`,
 						)
 					}
 					return router.push(

--- a/apps/epicdev-ai/src/app/(content)/_components/video-player-overlay.tsx
+++ b/apps/epicdev-ai/src/app/(content)/_components/video-player-overlay.tsx
@@ -66,6 +66,7 @@ export const CompletedLessonOverlay: React.FC<{
 }) => {
 	const { playerRef } = action
 	const workshopNavigation = useWorkshopNavigation()
+	const pathname = usePathname()
 	const {
 		nextResource: nextLesson,
 		prevResource: prevLesson,
@@ -73,9 +74,9 @@ export const CompletedLessonOverlay: React.FC<{
 	} = getAdjacentWorkshopResources(
 		workshopNavigation,
 		resource?.id as string,
-		usePathname().endsWith('/exercise')
+		pathname.endsWith('/exercise')
 			? 'exercise'
-			: usePathname().endsWith('/solution')
+			: pathname.endsWith('/solution')
 				? 'solution'
 				: 'lesson',
 	)

--- a/apps/epicdev-ai/src/app/(content)/workshops/[module]/[lesson]/(view)/shared-page.tsx
+++ b/apps/epicdev-ai/src/app/(content)/workshops/[module]/[lesson]/(view)/shared-page.tsx
@@ -26,7 +26,7 @@ import {
 } from '@/utils/get-current-ability-rules'
 import { joinUrlPath } from '@/utils/url'
 
-import { Skeleton } from '@coursebuilder/ui'
+import { Button, Skeleton } from '@coursebuilder/ui'
 import { VideoPlayerOverlayProvider } from '@coursebuilder/ui/hooks/use-video-player-overlay'
 
 import { LessonBody } from '../../../_components/lesson-body'
@@ -66,11 +66,15 @@ export async function LessonPage({
 		<ActiveHeadingProvider>
 			<main className="w-full">
 				{lessonType === 'exercise' ? (
-					<div className="bg-card flex aspect-video h-full max-h-[75vh] w-full items-center justify-center overflow-hidden rounded-t-lg border-b">
-						<div className="flex flex-col items-center justify-center gap-4">
-							<h2 className="text-2xl font-bold">Stop! 😅</h2>
-							<p className="text-center text-lg">This is not a video course.</p>
-							<p className="text-center text-lg">
+					<div className="bg-card flex h-full max-h-[75vh] w-full items-center justify-center overflow-hidden rounded-t-lg border-b p-10 md:aspect-video">
+						<div className="flex max-w-lg flex-col items-center justify-center gap-4 text-center">
+							<h2 className="text-2xl font-bold">
+								Stop! <span aria-hidden="true">😅</span>
+							</h2>
+							<p className="text-center text-base">
+								This is not a video course.
+							</p>
+							<p className="text-balance text-center text-base">
 								This workshop is intended to be worked through by completing
 								hands on exercises in your local development environment. It's
 								not meant for passive consumption.
@@ -78,20 +82,44 @@ export async function LessonPage({
 
 							{workshop?.fields?.workshopApp?.externalUrl &&
 							exercise?.fields?.workshopApp?.path ? (
-								<Link
-									target="_blank"
-									rel="noopener noreferrer"
-									href={joinUrlPath(
-										workshop.fields.workshopApp.externalUrl,
-										exercise.fields.workshopApp.path,
-									)}
-								>
-									Open in Workshop App
-								</Link>
+								<div className="mt-5 flex w-full max-w-xs flex-col items-center gap-2 text-center">
+									<Button
+										asChild
+										className="w-full"
+										size="lg"
+										variant="outline"
+									>
+										<Link
+											target="_blank"
+											rel="noopener noreferrer"
+											href={'/get-started'}
+										>
+											Setup Workshop App
+										</Link>
+									</Button>
+									<div className="flex w-full flex-col gap-2">
+										<Button asChild className="w-full" size="lg">
+											<Link
+												target="_blank"
+												rel="noopener noreferrer"
+												href={joinUrlPath(
+													workshop.fields.workshopApp.externalUrl,
+													exercise.fields.workshopApp.path,
+												)}
+											>
+												Open in Local Workshop App
+											</Link>
+										</Button>
+										<p className="text-foreground/80 text-xs">
+											Must be running on localhost:
+											{workshop.fields.workshopApp?.port || '5639'}
+										</p>
+									</div>
+								</div>
 							) : (
 								<p className="text-muted-foreground text-sm">
-									Exercise link unavailable — missing Workshop App
-									configuration.
+									Exercise link unavailable — missing workshop app configuration
+									or exercise.
 								</p>
 							)}
 						</div>

--- a/apps/epicdev-ai/src/app/(content)/workshops/[module]/[lesson]/(view)/shared-page.tsx
+++ b/apps/epicdev-ai/src/app/(content)/workshops/[module]/[lesson]/(view)/shared-page.tsx
@@ -66,7 +66,7 @@ export async function LessonPage({
 		<ActiveHeadingProvider>
 			<main className="w-full">
 				{lessonType === 'exercise' ? (
-					<div className="bg-card flex h-full max-h-[75vh] w-full items-center justify-center overflow-hidden rounded-t-lg border-b p-10 md:aspect-video">
+					<div className="dark:bg-muted bg-card flex h-full max-h-[75vh] w-full items-center justify-center overflow-hidden rounded-t-lg border-x border-b border-t p-10 md:aspect-video">
 						<div className="flex max-w-lg flex-col items-center justify-center gap-4 text-center">
 							<h2 className="text-2xl font-bold">
 								Stop! <span aria-hidden="true">😅</span>

--- a/apps/epicdev-ai/src/app/(content)/workshops/_components/workshop-resource-list.tsx
+++ b/apps/epicdev-ai/src/app/(content)/workshops/_components/workshop-resource-list.tsx
@@ -319,9 +319,7 @@ const LessonResource = ({
 	const params = useParams()
 	const pathname = usePathname()
 	const isOnSolution = pathname.includes('/solution')
-	const solution =
-		lesson.type === 'lesson' &&
-		lesson.resources?.find((resource) => resource.type === 'solution')
+
 	const isActiveSolution =
 		lesson.slug === params.lesson && pathname.includes('/solution')
 	const isOnExercise = pathname.includes('/exercise')
@@ -347,6 +345,14 @@ const LessonResource = ({
 	)
 
 	const canCreate = ability.can('create', 'Content')
+	const hasExercise =
+		(lesson?.type === 'lesson' &&
+			lesson.resources?.some((r) => r.type === 'exercise')) ||
+		false
+	const hasSolution =
+		(lesson?.type === 'lesson' &&
+			lesson.resources?.some((r) => r.type === 'solution')) ||
+		false
 
 	return (
 		<li
@@ -436,7 +442,7 @@ const LessonResource = ({
 					) : null}
 				</div>
 			</div>
-			{solution && isActiveGroup && (
+			{(hasSolution || hasExercise) && isActiveGroup && (
 				<ul>
 					<li data-active={isActiveLesson ? 'true' : 'false'}>
 						<Link
@@ -455,40 +461,44 @@ const LessonResource = ({
 							Problem
 						</Link>
 					</li>
-					<li data-active={isActiveExercise ? 'true' : 'false'}>
-						<Link
-							className={cn(
-								'hover:bg-foreground/20 relative flex w-full items-baseline py-3 pl-3 pr-10 font-medium',
-								{
-									'pl-9': true,
-									'bg-foreground/10 text-primary border-gray-200':
-										isActiveExercise,
-									'hover:text-primary': !isActiveExercise,
-								},
-							)}
-							prefetch={true}
-							href={`/workshops/${params.module}/${lesson.slug}/exercise`}
-						>
-							Exercise
-						</Link>
-					</li>
-					<li data-active={isActiveSolution ? 'true' : 'false'}>
-						<Link
-							className={cn(
-								'hover:bg-foreground/20 relative flex w-full items-baseline py-3 pl-3 pr-10 font-medium',
-								{
-									'pl-9': true,
-									'bg-foreground/10 text-primary border-gray-200':
-										isActiveSolution,
-									'hover:text-primary': !isActiveSolution,
-								},
-							)}
-							prefetch={true}
-							href={`/workshops/${params.module}/${lesson.slug}/solution`}
-						>
-							Solution
-						</Link>
-					</li>
+					{hasExercise && (
+						<li data-active={isActiveExercise ? 'true' : 'false'}>
+							<Link
+								className={cn(
+									'hover:bg-foreground/20 relative flex w-full items-baseline py-3 pl-3 pr-10 font-medium',
+									{
+										'pl-9': true,
+										'bg-foreground/10 text-primary border-gray-200':
+											isActiveExercise,
+										'hover:text-primary': !isActiveExercise,
+									},
+								)}
+								prefetch={true}
+								href={`/workshops/${params.module}/${lesson.slug}/exercise`}
+							>
+								Exercise
+							</Link>
+						</li>
+					)}
+					{hasSolution && (
+						<li data-active={isActiveSolution ? 'true' : 'false'}>
+							<Link
+								className={cn(
+									'hover:bg-foreground/20 relative flex w-full items-baseline py-3 pl-3 pr-10 font-medium',
+									{
+										'pl-9': true,
+										'bg-foreground/10 text-primary border-gray-200':
+											isActiveSolution,
+										'hover:text-primary': !isActiveSolution,
+									},
+								)}
+								prefetch={true}
+								href={`/workshops/${params.module}/${lesson.slug}/solution`}
+							>
+								Solution
+							</Link>
+						</li>
+					)}
 				</ul>
 			)}
 		</li>

--- a/apps/epicdev-ai/src/lib/workshops.ts
+++ b/apps/epicdev-ai/src/lib/workshops.ts
@@ -13,12 +13,20 @@ export const NavigationLessonSchema = z.object({
 	type: z.literal('lesson'),
 	resources: z
 		.array(
-			z.object({
-				id: z.string(),
-				slug: z.string(),
-				title: z.string(),
-				type: z.literal('solution'),
-			}),
+			z.discriminatedUnion('type', [
+				z.object({
+					id: z.string(),
+					slug: z.string(),
+					title: z.string(),
+					type: z.literal('solution'),
+				}),
+				z.object({
+					id: z.string(),
+					slug: z.string().nullish(),
+					title: z.string().nullish(),
+					type: z.literal('exercise'),
+				}),
+			]),
 		)
 		.optional()
 		.default([]),
@@ -147,6 +155,13 @@ export type SolutionRaw = {
 	resourceId: string
 }
 
+export type ExerciseRaw = {
+	id: string
+	slug?: string | null
+	title?: string | null
+	resourceId: string
+}
+
 // Schema for raw database results
 export const WorkshopRawSchema = z.object({
 	id: z.string(),
@@ -175,6 +190,13 @@ export const SolutionRawSchema = z.object({
 	id: z.string(),
 	slug: z.string(),
 	title: z.string(),
+	resourceId: z.string(),
+})
+
+export const ExerciseRawSchema = z.object({
+	id: z.string(),
+	slug: z.string().nullish(),
+	title: z.string().nullish(),
 	resourceId: z.string(),
 })
 
@@ -255,6 +277,27 @@ export const QueryResultRowSchema = z.discriminatedUnion('type', [
 		.extend({
 			...SolutionRawSchema.shape,
 			coverImage: z.null(), // Solutions don't have coverImage
+			position: z.null(),
+			sectionId: z.null(),
+			cohortId: z.null(),
+			cohortSlug: z.null(),
+			cohortTitle: z.null(),
+			startsAt: z.null(),
+			endsAt: z.null(),
+			timezone: z.null(),
+			cohortTier: z.null(),
+			maxSeats: z.null(),
+			resourceType: z.null(),
+			resourcePosition: z.null(),
+		}),
+	// Exercise row
+	z
+		.object({
+			type: z.literal('exercise'),
+		})
+		.extend({
+			...ExerciseRawSchema.shape,
+			coverImage: z.null(), // Exercises don't have coverImage
 			position: z.null(),
 			sectionId: z.null(),
 			cohortId: z.null(),

--- a/apps/epicdev-ai/src/utils/get-adjacent-workshop-resources.ts
+++ b/apps/epicdev-ai/src/utils/get-adjacent-workshop-resources.ts
@@ -12,35 +12,26 @@ export type AdjacentResource = {
 /**
  * Flattens all navigation resources, including nested solutions,
  * and returns the next and previous resources relative to the current one.
+ * Also determines if exercise or solution comes next based on current context.
  */
 export function getAdjacentWorkshopResources(
 	navigation: WorkshopNavigation | null,
 	currentResourceId: string,
+	currentContext?: 'lesson' | 'exercise' | 'solution', // Optional context from URL
 ): {
 	nextResource: AdjacentResource
 	prevResource: AdjacentResource
-	isSolutionNext: boolean
+	isSolutionNext: boolean // True if current resource is a lesson with solution OR an exercise (solution comes next)
+	isExerciseNext: boolean // True if current resource is a lesson with an exercise
 } {
 	const defaultReturn = {
 		nextResource: null,
 		prevResource: null,
 		isSolutionNext: false,
+		isExerciseNext: false,
 	}
 	if (!navigation) {
 		return defaultReturn
-	}
-
-	const lessonHasSolution = (lessonId: string) => {
-		if (!navigation) return false
-		const lesson = navigation.resources.find(
-			(r) => r.id === lessonId && r.type === 'lesson',
-		)
-		return (
-			lesson?.type === 'lesson' &&
-			lesson.resources &&
-			lesson.resources.length > 0 &&
-			lesson.resources.some((r: any) => r.type === 'solution')
-		)
 	}
 
 	// Create a fully flattened array of all resources, including lessons' solutions
@@ -53,12 +44,12 @@ export function getAdjacentWorkshopResources(
 		parentSlug?: string
 	}> = []
 
-	// Helper function to process a resource and its solutions
+	// Helper function to process a resource and create virtual entries for exercises/solutions
 	const processResource = (
 		resource: NavigationResource,
 		isInSection = false,
 	) => {
-		// Add the resource itself
+		// Add the resource itself (lesson/post)
 		flattenedNavResources.push({
 			id: resource.id,
 			slug: resource.slug,
@@ -66,21 +57,24 @@ export function getAdjacentWorkshopResources(
 			type: resource.type,
 		})
 
-		// Add solutions if this is a lesson with solutions
+		// Add solutions (exercises are just URL states, not separate resources)
 		if (
 			resource.type === 'lesson' &&
 			'resources' in resource &&
 			resource.resources?.length > 0
 		) {
-			resource.resources.forEach((solution) => {
-				flattenedNavResources.push({
-					id: solution.id,
-					slug: resource.slug, // Use parent lesson's slug for solution
-					title: solution.title,
-					type: solution.type,
-					parentId: resource.id,
-					parentSlug: resource.slug,
-				})
+			resource.resources.forEach((childResource) => {
+				// Only add actual solution resources
+				if (childResource.type === 'solution') {
+					flattenedNavResources.push({
+						id: childResource.id,
+						slug: childResource.slug || resource.slug,
+						title: childResource.title || resource.title,
+						type: childResource.type,
+						parentId: resource.id,
+						parentSlug: resource.slug,
+					})
+				}
 			})
 		}
 	}
@@ -107,12 +101,72 @@ export function getAdjacentWorkshopResources(
 	}
 
 	// Get the next and previous resources (if any)
-	const nextResource = flattenedNavResources[navIndex + 1] || null
+	let nextResource = flattenedNavResources[navIndex + 1] || null
 	const prevResource = flattenedNavResources[navIndex - 1] || null
+
+	// Simplified logic based on current context and lesson properties
+	const currentLesson = navigation.resources
+		.flatMap((r) => (r.type === 'section' ? r.resources : [r]))
+		.find((r) => r.id === currentResourceId && r.type === 'lesson')
+
+	const hasExercise =
+		(currentLesson?.type === 'lesson' &&
+			currentLesson.resources?.some((r) => r.type === 'exercise')) ||
+		false
+	const hasSolution =
+		(currentLesson?.type === 'lesson' &&
+			currentLesson.resources?.some((r) => r.type === 'solution')) ||
+		false
+
+	let isExerciseNext = false
+	let isSolutionNext = false
+
+	if (currentContext === 'lesson') {
+		// On lesson: exercise comes next if it exists, otherwise solution
+		isExerciseNext = hasExercise
+		isSolutionNext = !hasExercise && hasSolution
+
+		// Override nextResource for exercise/solution navigation
+		if (isExerciseNext) {
+			nextResource = {
+				id: `${currentResourceId}-exercise`,
+				slug: currentLesson?.slug || '',
+				title: 'Exercise',
+				type: 'exercise',
+				parentId: currentResourceId,
+				parentSlug: currentLesson?.slug || '',
+			}
+		} else if (isSolutionNext) {
+			nextResource = {
+				id: `${currentResourceId}-solution`,
+				slug: currentLesson?.slug || '',
+				title: "Kent's Solution",
+				type: 'solution',
+				parentId: currentResourceId,
+				parentSlug: currentLesson?.slug || '',
+			}
+		}
+	} else if (currentContext === 'exercise') {
+		// On exercise: solution comes next if it exists
+		isSolutionNext = hasSolution
+
+		if (isSolutionNext) {
+			nextResource = {
+				id: `${currentResourceId}-solution`,
+				slug: currentLesson?.slug || '',
+				title: "Kent's Solution",
+				type: 'solution',
+				parentId: currentResourceId,
+				parentSlug: currentLesson?.slug || '',
+			}
+		}
+	}
+	// On solution: use the actual next resource from navigation
 
 	return {
 		nextResource,
 		prevResource,
-		isSolutionNext: lessonHasSolution(currentResourceId),
+		isSolutionNext,
+		isExerciseNext,
 	}
 }

--- a/apps/epicdev-ai/src/utils/get-next-workshop-resource.ts
+++ b/apps/epicdev-ai/src/utils/get-next-workshop-resource.ts
@@ -34,7 +34,7 @@ export function getNextWorkshopResource(
 		resource: NavigationResource,
 		isInSection = false,
 	) => {
-		// Add the resource itself
+		// Add the resource itself (lesson/post)
 		flattenedNavResources.push({
 			id: resource.id,
 			slug: resource.slug,
@@ -42,21 +42,24 @@ export function getNextWorkshopResource(
 			type: resource.type,
 		})
 
-		// Add solutions if this is a lesson with solutions
+		// Add solutions (exercises are just URL states, not separate resources)
 		if (
 			resource.type === 'lesson' &&
 			'resources' in resource &&
 			resource.resources?.length > 0
 		) {
-			resource.resources.forEach((solution) => {
-				flattenedNavResources.push({
-					id: solution.id,
-					slug: resource.slug, // Use parent lesson's slug for solution
-					title: solution.title,
-					type: solution.type,
-					parentId: resource.id,
-					parentSlug: resource.slug,
-				})
+			resource.resources.forEach((childResource) => {
+				// Only add actual solution resources
+				if (childResource.type === 'solution') {
+					flattenedNavResources.push({
+						id: childResource.id,
+						slug: childResource.slug || resource.slug,
+						title: childResource.title || resource.title,
+						type: childResource.type,
+						parentId: resource.id,
+						parentSlug: resource.slug,
+					})
+				}
 			})
 		}
 	}

--- a/packages/utils-resource/src/resource-paths.ts
+++ b/packages/utils-resource/src/resource-paths.ts
@@ -126,6 +126,31 @@ const resourcePaths: Record<string, ResourcePathConfig> = {
 			return `/posts/${slug}/edit`
 		},
 	},
+	exercise: {
+		view: (slug, context) => {
+			if (context?.parentType === 'workshop') {
+				const parentSlug = context.parentSlug || context.getParentSlug?.()
+				if (!parentSlug) {
+					console.warn('No parent slug found for workshop lesson')
+					return `/${slug}`
+				}
+				return `/workshops/${parentSlug}/${slug}/exercise`
+			}
+
+			return `/${slug}`
+		},
+		edit: (slug, context) => {
+			if (context?.parentType === 'workshop') {
+				const parentSlug = context.parentSlug || context.getParentSlug?.()
+				if (!parentSlug) {
+					console.warn('No parent slug found for workshop lesson')
+					return `/posts/${slug}/edit`
+				}
+				return `/workshops/${parentSlug}/${slug}/edit`
+			}
+			return `/posts/${slug}/edit`
+		},
+	},
 }
 
 /**


### PR DESCRIPTION
<img width="800" alt="image" src="https://github.com/user-attachments/assets/e73b2f3f-0d2f-422f-8106-245f40332dc4" />

<img src="https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExdWV3MHhldzQ3eXV1MWE3eDFpMTgwaTkxYjc3dGs1amYwYm9rZ2N2cCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/pWO49XP9L7TxbgQVib/giphy.gif" width="250" alt="gif">

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Exercises are now first-class items with dedicated routes and links.
  - Context-aware navigation: next/previous adapt to lesson, exercise, or solution pages.
  - “Next Up” controls show Exercise and/or Solution buttons when applicable.
  - Continue actions support navigating directly to exercises.

- Style
  - Redesigned exercise banner with improved layout, accessibility, and two actions (Setup/Open Local).
  - Updated “Up Next” labels and sizing; workshop lists show separate Exercise and Solution entries.

- Bug Fixes
  - Lesson completion behavior adjusted to avoid auto-completing when next is an exercise or solution.

- Refactor
  - Smarter prefetching and URL handling for upcoming resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->