### PR TITLE
feat(eai): add access route for workshop content visibility

### DIFF
--- a/apps/epicdev-ai/src/app/api/workshops/[slug]/access/route.ts
+++ b/apps/epicdev-ai/src/app/api/workshops/[slug]/access/route.ts
@@ -63,10 +63,16 @@ export async function GET(
 		if (!isAdmin && workshop.fields?.startsAt) {
 			const timezone = workshop.fields?.timezone || 'America/Los_Angeles'
 			const nowInTZ = new Date(
-				formatInTimeZone(new Date(), timezone, "yyyy-MM-dd'T'HH:mm:ssXXX"),
+				formatInTimeZone(new Date(), timezone, "yyyy-MM-dd'T'HH:mm:ss"),
 			)
-			const startsAtDate = new Date(workshop.fields.startsAt)
-			workshopHasStarted = startsAtDate <= nowInTZ
+			const startsAtInTZ = new Date(
+				formatInTimeZone(
+					new Date(workshop.fields.startsAt),
+					timezone,
+					"yyyy-MM-dd'T'HH:mm:ss",
+				),
+			)
+			workshopHasStarted = startsAtInTZ <= nowInTZ
 		}
 
 		// Final decision: admin bypasses everything, others need content access + started

--- a/apps/epicdev-ai/src/app/api/workshops/[slug]/access/route.ts
+++ b/apps/epicdev-ai/src/app/api/workshops/[slug]/access/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createAppAbility, defineRulesForPurchases } from '@/ability'
+import { courseBuilderAdapter, db } from '@/db'
+import { getWorkshop } from '@/lib/workshops-query'
+import { getUserAbilityForRequest } from '@/server/ability-for-request'
+import { subject } from '@casl/ability'
+import { formatInTimeZone } from 'date-fns-tz'
+
+const corsHeaders = {
+	'Access-Control-Allow-Origin': '*',
+	'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+	'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+}
+
+export async function OPTIONS() {
+	return NextResponse.json({}, { headers: corsHeaders })
+}
+
+export async function GET(
+	request: NextRequest,
+	{ params }: { params: Promise<{ slug: string }> },
+) {
+	const { slug } = await params
+	try {
+		const { user } = await getUserAbilityForRequest(request)
+
+		if (!user) {
+			return NextResponse.json(false, { headers: corsHeaders })
+		}
+
+		// Get workshop to check start date
+		const workshop = await getWorkshop(slug)
+		if (!workshop) {
+			return NextResponse.json(false, { headers: corsHeaders })
+		}
+
+		// Get user purchases and create ability rules with device token user
+		const purchases = await courseBuilderAdapter.getPurchasesForUser(user.id)
+		const allEntitlementTypes = await db.query.entitlementTypes.findMany()
+
+		const abilityRules = defineRulesForPurchases({
+			user,
+			purchases,
+			module: workshop,
+			entitlementTypes: allEntitlementTypes,
+			country: request.headers.get('x-vercel-ip-country') || 'US',
+		})
+
+		const ability = createAppAbility(abilityRules || [])
+
+		// Check basic content access
+		const hasContentAccess = ability.can(
+			'read',
+			subject('Content', { id: workshop.id }),
+		)
+
+		// Check if user is admin (can bypass date restrictions)
+		const isAdmin = ability.can('create', 'Content')
+
+		// Check if workshop has started (for non-admin users)
+		let workshopHasStarted = true
+
+		if (!isAdmin && workshop.fields?.startsAt) {
+			const timezone = workshop.fields?.timezone || 'America/Los_Angeles'
+			const nowInTZ = new Date(
+				formatInTimeZone(new Date(), timezone, "yyyy-MM-dd'T'HH:mm:ssXXX"),
+			)
+			const startsAtDate = new Date(workshop.fields.startsAt)
+			workshopHasStarted = startsAtDate <= nowInTZ
+		}
+
+		// Final decision: admin bypasses everything, others need content access + started
+		const canViewContent = isAdmin || (hasContentAccess && workshopHasStarted)
+
+		return NextResponse.json(canViewContent, { headers: corsHeaders })
+	} catch (error) {
+		return NextResponse.json(false, { headers: corsHeaders })
+	}
+}
+
+export const dynamic = 'force-dynamic'


### PR DESCRIPTION
<img src="https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExNmZ2dGMwaGc5bmlnMWExMGNqYWdldGtiZnl1eGExOGhpM3pqMm5kYSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/vIvFtVKG0pP7DvK7Bg/giphy.gif" width="250" alt="gif">

- Implemented GET and OPTIONS endpoints to check user access to workshop content based on user purchases and workshop start date.
- Integrated ability checks using CASL for user permissions and entitlement types.
- Added CORS support for API responses to handle cross-origin requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public endpoint to check whether a user can view workshop content.
  * Access respects user entitlements and workshop start time with timezone-aware evaluation (defaults to America/Los_Angeles).
  * Admins are granted immediate access without date restrictions.
  * CORS support added for broader client compatibility.
  * Consistent boolean responses and graceful fallback on errors for a more reliable experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->