### PR TITLE
feat(eai): add API route for fetching workshop details

### DIFF
--- a/apps/epicdev-ai/src/app/api/workshops/[slug]/route.ts
+++ b/apps/epicdev-ai/src/app/api/workshops/[slug]/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createAppAbility, defineRulesForPurchases } from '@/ability'
+import { courseBuilderAdapter, db } from '@/db'
+import { getWorkshopViaApi } from '@/lib/workshops-query'
+import { getUserAbilityForRequest } from '@/server/ability-for-request'
+import { subject } from '@casl/ability'
+
+const corsHeaders = {
+	'Access-Control-Allow-Origin': '*',
+	'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+	'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+}
+
+export async function OPTIONS() {
+	return NextResponse.json({}, { headers: corsHeaders })
+}
+
+export async function GET(
+	request: NextRequest,
+	{ params }: { params: Promise<{ slug: string }> },
+) {
+	const { slug } = await params
+	try {
+		const workshop = await getWorkshopViaApi(slug)
+
+		if (!workshop) {
+			return NextResponse.json(null, { headers: corsHeaders })
+		}
+		return NextResponse.json(workshop, { headers: corsHeaders })
+	} catch (error) {
+		return NextResponse.json(null, { headers: corsHeaders })
+	}
+}
+
+export const dynamic = 'force-dynamic'

--- a/apps/epicdev-ai/src/lib/transform-workshop-result.ts
+++ b/apps/epicdev-ai/src/lib/transform-workshop-result.ts
@@ -1,0 +1,136 @@
+/**
+ * Transform workshop database result into the expected ModuleSchema format
+ *
+ * This function converts the nested database structure into a simplified
+ * format that matches the ModuleSchema requirements.
+ */
+
+interface DatabaseResource {
+	id: string
+	type: string
+	fields: {
+		slug?: string
+		title?: string
+		description?: string
+		state?: string
+		visibility?: string
+		body?: string
+		github?: string
+		optional?: boolean
+		thumbnailTime?: number
+		[key: string]: any
+	}
+	resources?: Array<{
+		resourceId: string
+		position: number
+		metadata?: any
+		resource: DatabaseResource
+	}>
+	[key: string]: any
+}
+
+interface ModuleResource {
+	_type: 'lesson' | 'exercise' | 'section'
+	_id: string
+	slug: string
+	lessons?: Array<{
+		_type: 'lesson' | 'exercise'
+		_id: string
+		slug: string
+	}>
+}
+
+interface ModuleResult {
+	resources: ModuleResource[] | null
+}
+
+/**
+ * Transform a database workshop result into ModuleSchema format
+ */
+export function transformWorkshopToModuleSchema(
+	workshop: DatabaseResource,
+): ModuleResult {
+	const resources: ModuleResource[] = []
+
+	// Process each top-level resource (sections and lessons)
+	workshop.resources?.forEach((resourceRelation) => {
+		const resource = resourceRelation.resource
+
+		if (resource.type === 'section') {
+			const section = transformSection(resource)
+			resources.push(section)
+		} else if (resource.type === 'lesson') {
+			const lesson = transformLesson(resource)
+			resources.push(lesson)
+		}
+	})
+
+	return {
+		resources: resources.length > 0 ? resources : null,
+	}
+}
+
+/**
+ * Transform a section resource
+ */
+function transformSection(section: DatabaseResource): ModuleResource {
+	const lessons: Array<{
+		_type: 'lesson' | 'exercise'
+		_id: string
+		slug: string
+	}> = []
+
+	// Process lessons within the section
+	section.resources?.forEach((resourceRelation) => {
+		const resource = resourceRelation.resource
+
+		if (resource.type === 'lesson') {
+			// Check if lesson has a solution to determine type
+			let hasSolution = false
+			resource.resources?.forEach((nestedResourceRelation) => {
+				if (nestedResourceRelation.resource.type === 'solution') {
+					hasSolution = true
+				}
+			})
+
+			lessons.push({
+				_type: hasSolution ? 'exercise' : 'lesson',
+				_id: resource.id,
+				slug: resource.fields.slug || '',
+			})
+		}
+	})
+
+	return {
+		_type: 'section',
+		_id: section.id,
+		slug: section.fields.slug || '',
+		lessons,
+	}
+}
+
+/**
+ * Transform a lesson resource
+ */
+function transformLesson(lesson: DatabaseResource): ModuleResource {
+	let hasSolution = false
+
+	// Look for solution in lesson resources
+	lesson.resources?.forEach((resourceRelation) => {
+		const resource = resourceRelation.resource
+
+		if (resource.type === 'solution') {
+			hasSolution = true
+		}
+	})
+
+	// Determine lesson type based on whether it has a solution
+	// lesson becomes exercise if it contains a solution
+	const lessonType = hasSolution ? 'exercise' : 'lesson'
+
+	return {
+		_type: lessonType,
+		_id: lesson.id,
+		slug: lesson.fields.slug || '',
+	}
+}

--- a/apps/epicdev-ai/src/lib/workshops-query.ts
+++ b/apps/epicdev-ai/src/lib/workshops-query.ts
@@ -618,6 +618,91 @@ export async function getMinimalWorkshop(moduleSlugOrId: string) {
 	return MinimalWorkshopSchema.parse(workshop)
 }
 
+export async function getWorkshopViaApi(moduleSlugOrId: string) {
+	const workshop = await db.query.contentResource.findFirst({
+		where: and(
+			or(
+				eq(
+					sql`JSON_EXTRACT (${contentResource.fields}, "$.slug")`,
+					moduleSlugOrId,
+				),
+				eq(contentResource.id, moduleSlugOrId),
+			),
+			eq(contentResource.type, 'workshop'),
+		),
+
+		with: {
+			resources: {
+				with: {
+					resource: {
+						with: {
+							resources: {
+								with: {
+									resource: {
+										extras: {
+											fields: sql<
+												Record<string, any>
+											>`JSON_REMOVE(${contentResource.fields}, '$.muxPlaybackId', '$.transcript', '$.wordLevelSrt', '$.srt', '$.deepgramResults', '$.muxAssetId', '$.originalMediaUrl')`.as(
+												'fields',
+											),
+										},
+										with: {
+											resources: {
+												with: {
+													resource: {
+														extras: {
+															fields: sql<
+																Record<string, any>
+															>`JSON_REMOVE(${contentResource.fields}, '$.muxPlaybackId', '$.transcript', '$.wordLevelSrt', '$.srt', '$.deepgramResults', '$.muxAssetId', '$.originalMediaUrl')`.as(
+																'fields',
+															),
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+								orderBy: asc(contentResourceResource.position),
+							},
+						},
+					},
+				},
+				orderBy: asc(contentResourceResource.position),
+			},
+		},
+	})
+
+	if (!workshop) {
+		return null
+	}
+
+	// Transform nested resources to apply field sanitization
+	const transformResource = (resource: any): any => {
+		if (!resource) return resource
+
+		const transformed = { ...resource }
+
+		// Transform nested resources
+		if (resource.resources) {
+			transformed.resources = resource.resources.map(
+				(resourceRelation: any) => ({
+					...resourceRelation,
+					resource: transformResource(resourceRelation.resource),
+				}),
+			)
+		}
+
+		return transformed
+	}
+
+	const sanitizedWorkshop = transformResource(workshop)
+
+	console.log('workshop', sanitizedWorkshop)
+
+	return sanitizedWorkshop
+}
+
 export async function getWorkshop(moduleSlugOrId: string) {
 	const { ability } = await getServerAuthSession()
 

--- a/apps/epicdev-ai/src/lib/workshops-query.ts
+++ b/apps/epicdev-ai/src/lib/workshops-query.ts
@@ -46,6 +46,7 @@ import {
 } from '@coursebuilder/core/schemas'
 import { last } from '@coursebuilder/nodash'
 
+import { transformWorkshopToModuleSchema } from './transform-workshop-result'
 import { upsertPostToTypeSense } from './typesense-query'
 
 /**
@@ -698,9 +699,12 @@ export async function getWorkshopViaApi(moduleSlugOrId: string) {
 
 	const sanitizedWorkshop = transformResource(workshop)
 
-	console.log('workshop', sanitizedWorkshop)
+	// Transform to ModuleSchema format
+	const transformedWorkshop = transformWorkshopToModuleSchema(sanitizedWorkshop)
 
-	return sanitizedWorkshop
+	console.log('workshop', transformedWorkshop)
+
+	return transformedWorkshop
 }
 
 export async function getWorkshop(moduleSlugOrId: string) {


### PR DESCRIPTION
<img src="https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExNTdqN25zMXpvZWlxNGljcHpxNTJjNzh6YXp6NmRxZWY2a3A2ZGxwbCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/QNFhOolVeCzPQ2Mx85/giphy.gif" width="250" alt="gif">

- Introduced a new route for workshop access, implementing GET and OPTIONS methods.
- Integrated CORS headers for cross-origin requests.
- Added logic to fetch workshop data from the database, including nested resource transformation for field sanitization.
- Enhanced error handling to return appropriate responses when workshops are not found.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public API endpoint to fetch workshop details by slug or ID with CORS support.
  * Responses return comprehensive, normalized workshop data and related resources.
  * Dynamically rendered, always-fresh responses.
  * Payloads are sanitized to remove sensitive fields before returning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->