### PR TITLE
feat(edai): get started page

### DIFF
--- a/apps/epicdev-ai/src/app/(content)/workshops/[module]/[lesson]/(view)/shared-page.tsx
+++ b/apps/epicdev-ai/src/app/(content)/workshops/[module]/[lesson]/(view)/shared-page.tsx
@@ -90,12 +90,8 @@ export async function LessonPage({
 											size="lg"
 											variant="outline"
 										>
-											<Link
-												target="_blank"
-												rel="noopener noreferrer"
-												href={workshop.fields.github}
-											>
-												Setup Workshop App
+											<Link target="_blank" href="/get-started">
+												Get Started
 											</Link>
 										</Button>
 									)}
@@ -160,12 +156,8 @@ export async function LessonPage({
 										asChild
 										className="from-primary relative mt-4 h-10 rounded-lg bg-gradient-to-b to-indigo-800 text-base font-medium text-white shadow-[0px_4px_38px_-14px_rgba(0,_0,_0,_0.1)]"
 									>
-										<Link
-											target="_blank"
-											rel="noopener noreferrer"
-											href={`${workshop?.fields?.github}#readme`}
-										>
-											Setup Workshop App
+										<Link target="_blank" href="/get-started">
+											Get Started
 										</Link>
 									</Button>
 								</div>

--- a/apps/epicdev-ai/src/app/get-started/_components/app-tour-video.tsx
+++ b/apps/epicdev-ai/src/app/get-started/_components/app-tour-video.tsx
@@ -1,0 +1,19 @@
+import MuxPlayer from '@mux/mux-player-react'
+
+const AppTourVideo = ({
+	playbackId = 'xSI7201jJf6lumgc9Kxwd5C65Rg8kLa94CcYzifZaL4U',
+}: {
+	playbackId?: string
+}) => {
+	return (
+		<MuxPlayer
+			playbackId={playbackId}
+			accentColor="#3b82f6"
+			className="w-full rounded"
+			metadata={{
+				video_title: 'AppTourVideo',
+			}}
+		/>
+	)
+}
+export default AppTourVideo

--- a/apps/epicdev-ai/src/app/get-started/_components/app-tour-video.tsx
+++ b/apps/epicdev-ai/src/app/get-started/_components/app-tour-video.tsx
@@ -1,3 +1,4 @@
+'use client'
 import MuxPlayer from '@mux/mux-player-react'
 
 const AppTourVideo = ({

--- a/apps/epicdev-ai/src/app/get-started/_components/app-tour-video.tsx
+++ b/apps/epicdev-ai/src/app/get-started/_components/app-tour-video.tsx
@@ -1,4 +1,5 @@
 'use client'
+
 import MuxPlayer from '@mux/mux-player-react'
 
 const AppTourVideo = ({

--- a/apps/epicdev-ai/src/app/get-started/_components/get-started-client.tsx
+++ b/apps/epicdev-ai/src/app/get-started/_components/get-started-client.tsx
@@ -45,6 +45,7 @@ export default function GetStartedClient({
 						className="bg-primary text-primary-foreground mt-10 flex items-center gap-3 rounded-md px-5 py-1 font-semibold transition"
 						href={`${githubUrlForCurrentModule}?tab=readme-ov-file#setup`}
 						target="_blank"
+						rel="noopener noreferrer"
 					>
 						{currentModule.fields.coverImage?.url && (
 							<Image

--- a/apps/epicdev-ai/src/app/get-started/_components/get-started-client.tsx
+++ b/apps/epicdev-ai/src/app/get-started/_components/get-started-client.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import React from 'react'
+import Image from 'next/image'
+import Link from 'next/link'
+import { useSearchParams } from 'next/navigation'
+import { type Page } from '@/lib/pages'
+import { type Workshop } from '@/lib/workshops'
+import Balancer from 'react-wrap-balancer'
+
+import WorkshopAppScreenshot from './workshop-app-screenshot'
+
+interface GetStartedClientProps {
+	page: Page
+	workshops: Workshop[]
+	pageTitle: string
+	pageDescription: string
+	children: React.ReactNode
+}
+
+export default function GetStartedClient({
+	page,
+	workshops,
+	pageTitle,
+	pageDescription,
+	children,
+}: GetStartedClientProps) {
+	const searchParams = useSearchParams()
+	const moduleSlug = searchParams.get('module')
+	const currentModule = [...workshops].find(
+		(module) => module.fields.slug === moduleSlug,
+	)
+	const githubUrlForCurrentModule = currentModule?.fields.github
+
+	React.useEffect(() => {}, [])
+
+	return (
+		<>
+			<header className="mx-auto flex w-full max-w-screen-md flex-col items-center justify-center px-5 pb-16 pt-10 sm:pt-14">
+				<h1 className="text-center text-3xl font-bold sm:text-4xl lg:text-5xl">
+					<Balancer>{pageTitle}</Balancer>
+				</h1>
+				{githubUrlForCurrentModule ? (
+					<Link
+						className="bg-primary text-primary-foreground mt-10 flex items-center gap-3 rounded-md px-5 py-1 font-semibold transition"
+						href={`${githubUrlForCurrentModule}?tab=readme-ov-file#setup`}
+						target="_blank"
+					>
+						{currentModule.fields.coverImage?.url && (
+							<Image
+								src={currentModule.fields.coverImage.url}
+								width={50}
+								height={50}
+								aria-hidden
+								alt=""
+							/>
+						)}{' '}
+						<span className="drop-shadow-md">{currentModule.fields.title}</span>
+					</Link>
+				) : null}
+				<h2 className="pb-8 pt-8 text-center text-lg text-gray-700 sm:text-xl lg:text-2xl dark:text-gray-300">
+					<Balancer>{pageDescription}</Balancer>
+				</h2>
+				<WorkshopAppScreenshot />
+			</header>
+			<main className="prose dark:prose-invert md:prose-lg prose-headings:pt-8 mx-auto w-full max-w-screen-md px-5 pb-16">
+				{page.fields.body ? children : null}
+			</main>
+		</>
+	)
+}

--- a/apps/epicdev-ai/src/app/get-started/_components/theme-aware-image.tsx
+++ b/apps/epicdev-ai/src/app/get-started/_components/theme-aware-image.tsx
@@ -15,7 +15,7 @@ export default function ThemeAwareImage({
 	dark?: string
 	alt?: string
 }) {
-	const { theme } = useTheme()
+	const { resolvedTheme } = useTheme()
 	const [mounted, setMounted] = React.useState(false)
 
 	React.useEffect(() => {
@@ -29,7 +29,8 @@ export default function ThemeAwareImage({
 			{mounted ? (
 				<Image
 					src={
-						typeof src === 'string' ? src : theme === 'light' ? light! : dark!
+						src ??
+						(resolvedTheme === 'light' ? (light ?? dark) : (dark ?? light))!
 					}
 					fill
 					alt={alt}

--- a/apps/epicdev-ai/src/app/get-started/_components/theme-aware-image.tsx
+++ b/apps/epicdev-ai/src/app/get-started/_components/theme-aware-image.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import React from 'react'
+import Image from 'next/image'
+import { useTheme } from 'next-themes'
+
+export default function ThemeAwareImage({
+	src,
+	light,
+	dark,
+	alt = '',
+}: {
+	src?: string
+	light?: string
+	dark?: string
+	alt?: string
+}) {
+	const { theme } = useTheme()
+	const [mounted, setMounted] = React.useState(false)
+
+	React.useEffect(() => {
+		setMounted(true)
+	}, [])
+
+	if (!src && !light && !dark) return null
+
+	return (
+		<div className="relative aspect-video">
+			{mounted ? (
+				<Image
+					src={
+						typeof src === 'string' ? src : theme === 'light' ? light! : dark!
+					}
+					fill
+					alt={alt}
+					aria-hidden={!alt}
+				/>
+			) : null}
+		</div>
+	)
+}

--- a/apps/epicdev-ai/src/app/get-started/_components/workshop-app-screenshot.tsx
+++ b/apps/epicdev-ai/src/app/get-started/_components/workshop-app-screenshot.tsx
@@ -15,7 +15,7 @@ const WorkshopAppScreenshot = () => {
 		['0deg', '-3deg'],
 	)
 
-	const { theme } = useTheme()
+	const { resolvedTheme } = useTheme()
 	const [mounted, setMounted] = React.useState(false)
 	React.useEffect(() => {
 		setMounted(true)
@@ -33,7 +33,7 @@ const WorkshopAppScreenshot = () => {
 			{mounted ? (
 				<Image
 					src={
-						theme === 'light'
+						resolvedTheme === 'light'
 							? 'https://res.cloudinary.com/epic-web/image/upload/v1696929540/workshop-app-screenshot-light-1_2x.png'
 							: 'https://res.cloudinary.com/epic-web/image/upload/v1696929542/workshop-app-screenshot-1_2x.png'
 					}

--- a/apps/epicdev-ai/src/app/get-started/_components/workshop-app-screenshot.tsx
+++ b/apps/epicdev-ai/src/app/get-started/_components/workshop-app-screenshot.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import React from 'react'
+import Image from 'next/image'
+import { motion, useScroll, useTransform } from 'framer-motion'
+import { useTheme } from 'next-themes'
+
+const WorkshopAppScreenshot = () => {
+	const { scrollY } = useScroll()
+	const welcomeBannerScrollAnimation = useTransform(
+		scrollY,
+		// Map y from these values:
+		[0, 600],
+		// Into these values:
+		['0deg', '-3deg'],
+	)
+
+	const { theme } = useTheme()
+	const [mounted, setMounted] = React.useState(false)
+	React.useEffect(() => {
+		setMounted(true)
+	}, [])
+
+	return (
+		<motion.div
+			style={{
+				transformOrigin: 'top center',
+				transformPerspective: 300,
+				rotateX: welcomeBannerScrollAnimation,
+			}}
+			className="aspect-[1520/1090] h-full w-full"
+		>
+			{mounted ? (
+				<Image
+					src={
+						theme === 'light'
+							? 'https://res.cloudinary.com/epic-web/image/upload/v1696929540/workshop-app-screenshot-light-1_2x.png'
+							: 'https://res.cloudinary.com/epic-web/image/upload/v1696929542/workshop-app-screenshot-1_2x.png'
+					}
+					width={1520}
+					quality={100}
+					height={1090}
+					alt=""
+					aria-hidden
+					priority
+				/>
+			) : null}
+		</motion.div>
+	)
+}
+export default WorkshopAppScreenshot

--- a/apps/epicdev-ai/src/app/get-started/_components/workshops.tsx
+++ b/apps/epicdev-ai/src/app/get-started/_components/workshops.tsx
@@ -7,20 +7,15 @@ import { Workshop } from '@/lib/workshops'
 import { GlobeIcon } from 'lucide-react'
 
 const Workshops: React.FC<{ workshops: Workshop[] }> = ({ workshops }) => {
-	console.log({ workshops })
-	// log workshop fields
-	console.log(workshops.map((workshop) => workshop.fields))
-
 	const publishedWorkshops = workshops.filter(
 		(workshop) => workshop.fields.state === 'published',
 	)
 
-	console.log({ publishedWorkshops })
 	return (
 		<div className="not-prose my-8 flex flex-col items-center justify-center text-lg sm:gap-4 md:text-lg">
 			<strong className="flex w-full">Workshops</strong>
 			<ul className="w-full divide-y pb-5">
-				{workshops.map((workshop) => {
+				{publishedWorkshops.map((workshop) => {
 					return <ModuleWorkshopAppItem key={workshop.id} module={workshop} />
 				})}
 			</ul>
@@ -61,7 +56,6 @@ const ModuleWorkshopAppItem = ({ module }: { module: Workshop }) => {
 						aria-hidden
 					/>
 				) : null}
-				<Link
 				<Link
 					href={module.fields.github}
 					target="_blank"

--- a/apps/epicdev-ai/src/app/get-started/_components/workshops.tsx
+++ b/apps/epicdev-ai/src/app/get-started/_components/workshops.tsx
@@ -62,8 +62,10 @@ const ModuleWorkshopAppItem = ({ module }: { module: Workshop }) => {
 					/>
 				) : null}
 				<Link
+				<Link
 					href={module.fields.github}
 					target="_blank"
+					rel="noopener noreferrer"
 					className="group leading-tight hover:underline"
 				>
 					{module.fields.title}{' '}
@@ -76,7 +78,7 @@ const ModuleWorkshopAppItem = ({ module }: { module: Workshop }) => {
 				{deployedUrl && (
 					<Link
 						target="_blank"
-						rel="noopener"
+						rel="noopener noreferrer"
 						className="inline-flex items-center gap-1.5 hover:underline"
 						href={deployedUrl}
 					>
@@ -87,7 +89,7 @@ const ModuleWorkshopAppItem = ({ module }: { module: Workshop }) => {
 				<Link
 					href={module.fields.github + '?tab=readme-ov-file#setup'}
 					target="_blank"
-					rel="noopener"
+					rel="noopener noreferrer"
 					className="inline-flex items-center gap-1.5 hover:underline"
 				>
 					<Icon name="Github" size="16" className="opacity-75" />

--- a/apps/epicdev-ai/src/app/get-started/_components/workshops.tsx
+++ b/apps/epicdev-ai/src/app/get-started/_components/workshops.tsx
@@ -1,0 +1,99 @@
+'use client'
+
+import Image from 'next/image'
+import Link from 'next/link'
+import { Icon } from '@/components/brand/icons'
+import { Workshop } from '@/lib/workshops'
+import { GlobeIcon } from 'lucide-react'
+
+const Workshops: React.FC<{ workshops: Workshop[] }> = ({ workshops }) => {
+	console.log({ workshops })
+	// log workshop fields
+	console.log(workshops.map((workshop) => workshop.fields))
+
+	const publishedWorkshops = workshops.filter(
+		(workshop) => workshop.fields.state === 'published',
+	)
+
+	console.log({ publishedWorkshops })
+	return (
+		<div className="not-prose my-8 flex flex-col items-center justify-center text-lg sm:gap-4 md:text-lg">
+			<strong className="flex w-full">Workshops</strong>
+			<ul className="w-full divide-y pb-5">
+				{workshops.map((workshop) => {
+					return <ModuleWorkshopAppItem key={workshop.id} module={workshop} />
+				})}
+			</ul>
+			{/* {tutorials.length > 0 && (
+        <>
+          <strong className="flex w-full">Tutorials</strong>
+          <ul className="w-full divide-y">
+            {tutorials.map((tutorial) => {
+              return (
+                <ModuleWorkshopAppItem key={tutorial.id} module={tutorial} />
+              )
+            })}
+          </ul>
+        </>
+      )} */}
+		</div>
+	)
+}
+export default Workshops
+
+const ModuleWorkshopAppItem = ({ module }: { module: Workshop }) => {
+	if (!module?.fields.github) return null
+
+	const deployedUrl = module?.fields.workshopApp?.externalUrl
+
+	return (
+		<li
+			key={module.id}
+			className="flex min-h-[56px] w-full flex-col justify-between gap-2 py-4 font-semibold sm:flex-row sm:items-center sm:gap-5 sm:py-2"
+		>
+			<div className="flex items-center gap-3">
+				{module.fields.coverImage?.url ? (
+					<Image
+						src={module.fields.coverImage?.url}
+						width={50}
+						height={50}
+						alt={module.fields.title}
+						aria-hidden
+					/>
+				) : null}
+				<Link
+					href={module.fields.github}
+					target="_blank"
+					className="group leading-tight hover:underline"
+				>
+					{module.fields.title}{' '}
+					<span className="opacity-50 transition group-hover:opacity-100">
+						↗︎
+					</span>
+				</Link>
+			</div>
+			<div className="flex flex-shrink-0 items-center justify-end gap-5 pr-5 text-sm font-medium">
+				{deployedUrl && (
+					<Link
+						target="_blank"
+						rel="noopener"
+						className="inline-flex items-center gap-1.5 hover:underline"
+						href={deployedUrl}
+					>
+						<GlobeIcon className="h-4 w-4 opacity-75" />
+						Deployed Version
+					</Link>
+				)}
+				<Link
+					href={module.fields.github + '?tab=readme-ov-file#setup'}
+					target="_blank"
+					rel="noopener"
+					className="inline-flex items-center gap-1.5 hover:underline"
+				>
+					<Icon name="Github" size="16" className="opacity-75" />
+					Setup
+				</Link>
+			</div>
+		</li>
+	)
+}

--- a/apps/epicdev-ai/src/app/get-started/page.tsx
+++ b/apps/epicdev-ai/src/app/get-started/page.tsx
@@ -1,0 +1,41 @@
+import { notFound } from 'next/navigation'
+import { getPage } from '@/lib/pages-query'
+import { getAllTutorials } from '@/lib/tutorials-query'
+import { getAllWorkshops } from '@/lib/workshops-query'
+import { compileMDX } from '@/utils/compile-mdx'
+
+import AppTourVideo from './_components/app-tour-video'
+import GetStartedClient from './_components/get-started-client'
+import ThemeAwareImage from './_components/theme-aware-image'
+import WorkshopsComponent from './_components/workshops'
+
+export default async function GetStartedPage() {
+	const page = await getPage('get-started-6pc7h')
+	if (!page) {
+		notFound()
+	}
+
+	const workshops = await getAllWorkshops()
+
+	const { content } = await compileMDX(page.fields.body || '', {
+		AppTourVideo,
+		Workshops: () => <WorkshopsComponent workshops={workshops} />,
+		Image: ThemeAwareImage,
+	})
+
+	const pageTitle = page.fields.title || 'Get Started Using the Workshop App'
+	const pageDescription =
+		page.fields.description ||
+		"From setting up your environment to navigating exercises and understanding the Epic Workshop App's structure, this guide ensures a smooth workshop experience."
+
+	return (
+		<GetStartedClient
+			page={page}
+			workshops={workshops}
+			pageTitle={pageTitle}
+			pageDescription={pageDescription}
+		>
+			{content}
+		</GetStartedClient>
+	)
+}

--- a/apps/epicdev-ai/src/app/get-started/page.tsx
+++ b/apps/epicdev-ai/src/app/get-started/page.tsx
@@ -1,4 +1,5 @@
 import { notFound } from 'next/navigation'
+import LayoutClient from '@/components/layout-client'
 import { getPage } from '@/lib/pages-query'
 import { getAllTutorials } from '@/lib/tutorials-query'
 import { getAllWorkshops } from '@/lib/workshops-query'
@@ -29,13 +30,15 @@ export default async function GetStartedPage() {
 		"From setting up your environment to navigating exercises and understanding the Epic Workshop App's structure, this guide ensures a smooth workshop experience."
 
 	return (
-		<GetStartedClient
-			page={page}
-			workshops={workshops}
-			pageTitle={pageTitle}
-			pageDescription={pageDescription}
-		>
-			{content}
-		</GetStartedClient>
+		<LayoutClient withContainer>
+			<GetStartedClient
+				page={page}
+				workshops={workshops}
+				pageTitle={pageTitle}
+				pageDescription={pageDescription}
+			>
+				{content}
+			</GetStartedClient>
+		</LayoutClient>
 	)
 }


### PR DESCRIPTION
<img width="4228" height="3584" alt="image" src="https://github.com/user-attachments/assets/ec0b514b-d75e-46a4-ae26-64ec939b38bd" />
<img width="4228" height="4892" alt="image" src="https://github.com/user-attachments/assets/249078b0-ee47-4ab3-88d8-d5c561acf462" />


![gif](https://media0.giphy.com/media/13NKbbVWMt6nFm/giphy.gif?cid=1927fc1bj4vpya05mmcoqydk3ckhf6r9a624pdgnaxqod9i7&ep=v1_gifs_search&rid=giphy.gif&ct=g)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Get Started” page featuring an app tour video, curated workshops list (with deployed links and setup actions), and a module-aware header.
  * Replaced external “Setup Workshop App” buttons with an internal “Get Started” link for smoother onboarding.
* **Style**
  * Introduced theme-aware images and a subtle 3D scroll animation on app screenshots for a more polished visual experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->