### PR TITLE
feat(eai): add discord info to oauth/userinfo

### DIFF
--- a/apps/epicdev-ai/src/app/oauth/userinfo/get-user.ts
+++ b/apps/epicdev-ai/src/app/oauth/userinfo/get-user.ts
@@ -8,5 +8,13 @@ export async function getUser(userId: string | null) {
 	}
 	return db.query.users.findFirst({
 		where: eq(users.id, userId),
+		with: {
+			accounts: {
+				columns: {
+					provider: true,
+					providerAccountId: true,
+				},
+			},
+		},
 	})
 }

--- a/apps/epicdev-ai/src/app/oauth/userinfo/route.ts
+++ b/apps/epicdev-ai/src/app/oauth/userinfo/route.ts
@@ -2,6 +2,7 @@ import { headers } from 'next/headers'
 import { NextResponse } from 'next/server'
 import { db } from '@/db'
 import { deviceAccessToken as deviceAccessTokenTable } from '@/db/schema'
+import { getDiscordUser } from '@/lib/discord-query'
 import { eq } from 'drizzle-orm'
 
 import { getUser } from './get-user'
@@ -17,7 +18,13 @@ export async function GET(request: Request) {
 		if (token?.userId) {
 			const user = await getUser(token.userId)
 
-			return NextResponse.json({ ...user })
+			const discordAccountId = user?.accounts?.find(
+				(account) => account.provider === 'discord',
+			)?.providerAccountId
+
+			const discordProfile = await getDiscordUser(discordAccountId || null)
+
+			return NextResponse.json({ ...user, discordProfile })
 		} else {
 			return NextResponse.json(
 				{

--- a/apps/epicdev-ai/src/lib/discord-query.ts
+++ b/apps/epicdev-ai/src/lib/discord-query.ts
@@ -3,6 +3,7 @@
 import { db } from '@/db'
 import { accounts, users } from '@/db/schema'
 import { env } from '@/env.mjs'
+import { DiscordMember } from '@/lib/discord'
 import { getServerAuthSession } from '@/server/auth'
 import { and, eq } from 'drizzle-orm'
 
@@ -62,4 +63,17 @@ export async function fetchAsDiscordBot(
 			...config?.headers,
 		},
 	})
+}
+
+export async function getDiscordUser(accountId: string | null) {
+	if (!accountId) return null
+
+	try {
+		return fetchJsonAsDiscordBot<DiscordMember>(
+			`guilds/${env.DISCORD_GUILD_ID}/members/${accountId}`,
+		)
+	} catch (error) {
+		console.error('Error fetching Discord user:', error)
+		return null
+	}
 }


### PR DESCRIPTION

<img width="3524" height="2992" alt="image" src="https://github.com/user-attachments/assets/cc77cf3c-6488-4c20-825c-3df33c4fc89e" />


![gif](https://media1.giphy.com/media/MXet8zFVbgEeI/giphy.gif?cid=1927fc1bbyaxql5h04tbe85jl5kchunufb1dwvtw2kydh10k&ep=v1_gifs_search&rid=giphy.gif&ct=g)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - User info responses now include Discord profile details when the account is linked, providing richer data to clients.

- Enhancements
  - Improved user lookup by eagerly loading connected accounts, reducing additional queries.
  - Discord profile retrieval is resilient: if unavailable or an error occurs, the response gracefully omits it without failing.

- Tests
  - No user-facing changes to authorization or error responses; existing behaviors remain intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->